### PR TITLE
Add linkml semantic schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ When the current set of terms does not meet the needs of new methods,  protocols
 To propose a new term, the proposer will complete a [New Taxonomy Term Proposal form](https://airtable.com/appzrw40tJdLBM2RS/shrssvqyirhVLP7bz). New term proposals must include the new term, its definition, an icon, the taxonomic group (Activities, Impact, Environment Type), and a brief justification for adding the new term. Content from the form will be evaluated by a Regen Registry staff member and if the information is complete and it conforms to the taxonomy standards the staff member will initiate the approval process of adding the new term, definition and icon  creating a pull request on this repository. 
 
 We are using GitHub as the governance platform to approve new taxonomy components. The person submitting the pull request will select at least two people from a pool of approvers who can approve merging taxonomy components into the repository by suggesting changes and then accepting proposed additions using pull requests. The approvers are accountable for adding new terms and are encouraged to follow a due diligence process and, when necessary, solicit comments from other people, inside and outside of Regen Network, before approving a pull request.
+
+## Schemas
+
+Schemas for the Regen Network Framework are documented. See [/schema/README.md](schema/README.md)

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,8 @@ import {defineConfig} from 'astro/config';
 import tailwind from '@astrojs/tailwind';
 import pagefind from "astro-pagefind";
 import mdx from '@astrojs/mdx';
+import rehypeMermaid from "rehype-mermaid";
+import {rehypeShiki} from "@astrojs/markdown-remark";
 
 // https://astro.build/config
 export default defineConfig({
@@ -11,4 +13,11 @@ export default defineConfig({
         pagefind(),
         mdx(),
     ],
+    markdown: {
+        rehypePlugins: [
+            rehypeMermaid,
+            rehypeShiki,
+        ],
+        syntaxHighlight: false,
+    },
 });

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,8 +2,6 @@ import {defineConfig} from 'astro/config';
 import tailwind from '@astrojs/tailwind';
 import pagefind from "astro-pagefind";
 import mdx from '@astrojs/mdx';
-import rehypeMermaid from "rehype-mermaid";
-import {rehypeShiki} from "@astrojs/markdown-remark";
 
 // https://astro.build/config
 export default defineConfig({
@@ -13,11 +11,4 @@ export default defineConfig({
         pagefind(),
         mdx(),
     ],
-    markdown: {
-        rehypePlugins: [
-            rehypeMermaid,
-            rehypeShiki,
-        ],
-        syntaxHighlight: false,
-    },
 });

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,4 +11,7 @@ export default defineConfig({
         pagefind(),
         mdx(),
     ],
+    redirects: {
+        '/schema/[...slug].md': '/schema/[...slug]',
+    }
 });

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,7 +5,9 @@ import mdx from '@astrojs/mdx';
 
 // https://astro.build/config
 export default defineConfig({
-    trailingSlash: 'never',
+    build: {
+        format: 'file',
+    },
     prefetch: true,
     integrations: [
         tailwind({}),

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import mdx from '@astrojs/mdx';
 
 // https://astro.build/config
 export default defineConfig({
+    trailingSlash: 'never',
     prefetch: true,
     integrations: [
         tailwind({}),

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.7.0",
+    "@astrojs/markdown-remark": "^5.2.0",
     "@astrojs/mdx": "^3.0.1",
     "@astrojs/tailwind": "^5.1.0",
     "@iconify-json/radix-icons": "^1.1.14",
@@ -19,6 +20,7 @@
     "astro": "^4.9.2",
     "astro-pagefind": "^1.5.0",
     "pagefind": "^1.1.0",
+    "rehype-mermaid": "^2.1.0",
     "sharp": "^0.33.4",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.4.5"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.7.0",
-    "@astrojs/markdown-remark": "^5.2.0",
     "@astrojs/mdx": "^3.0.1",
     "@astrojs/tailwind": "^5.1.0",
     "@iconify-json/radix-icons": "^1.1.14",
@@ -20,7 +19,6 @@
     "astro": "^4.9.2",
     "astro-pagefind": "^1.5.0",
     "pagefind": "^1.1.0",
-    "rehype-mermaid": "^2.1.0",
     "sharp": "^0.33.4",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.4.5"

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,16 @@
+# Schema
+
+[LinkML](https://linkml.io/) semantic schemas for Regen Network framework.
+
+## Requirements
+
+[Install LinkML](https://linkml.io/linkml/intro/install.html) to use the helper and generator commands for interacting with LinkML schemas and data.
+
+## Structure
+
+- LinkML schemas are created in `schema/src`.
+- Create separate schema files for each logical schema class and `import` into the root `schemas.yaml` file.
+- Generated markdown from schemas:
+    ```shell
+    gen-doc schema/src/schemas.yml --directory schema/generated --diagram-type er_diagram
+    ```

--- a/schema/generated/Boolean.md
+++ b/schema/generated/Boolean.md
@@ -1,0 +1,50 @@
+# Type: Boolean
+
+
+
+
+_A binary (true or false) value_
+
+
+
+URI: [xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean)
+
+* [base](https://w3id.org/linkml/base): Bool
+
+* [uri](https://w3id.org/linkml/uri): xsd:boolean
+
+* [repr](https://w3id.org/linkml/repr): bool
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:boolean |
+| native | rfs:boolean |
+| exact | schema:Boolean |
+
+
+

--- a/schema/generated/Curie.md
+++ b/schema/generated/Curie.md
@@ -1,0 +1,54 @@
+# Type: Curie
+
+
+
+
+_a compact URI_
+
+
+
+URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+* [base](https://w3id.org/linkml/base): Curie
+
+* [uri](https://w3id.org/linkml/uri): xsd:string
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Comments
+
+* in RDF serializations this MUST be expanded to a URI
+* in non-RDF serializations MAY be serialized as the compact representation
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:string |
+| native | rfs:curie |
+
+
+

--- a/schema/generated/Date.md
+++ b/schema/generated/Date.md
@@ -1,0 +1,50 @@
+# Type: Date
+
+
+
+
+_a date (year, month and day) in an idealized calendar_
+
+
+
+URI: [xsd:date](http://www.w3.org/2001/XMLSchema#date)
+
+* [base](https://w3id.org/linkml/base): XSDDate
+
+* [uri](https://w3id.org/linkml/uri): xsd:date
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:date |
+| native | rfs:date |
+| exact | schema:Date |
+
+
+

--- a/schema/generated/DateOrDatetime.md
+++ b/schema/generated/DateOrDatetime.md
@@ -1,0 +1,49 @@
+# Type: DateOrDatetime
+
+
+
+
+_Either a date or a datetime_
+
+
+
+URI: [linkml:DateOrDatetime](https://w3id.org/linkml/DateOrDatetime)
+
+* [base](https://w3id.org/linkml/base): str
+
+* [uri](https://w3id.org/linkml/uri): linkml:DateOrDatetime
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | linkml:DateOrDatetime |
+| native | rfs:date_or_datetime |
+
+
+

--- a/schema/generated/Datetime.md
+++ b/schema/generated/Datetime.md
@@ -1,0 +1,50 @@
+# Type: Datetime
+
+
+
+
+_The combination of a date and time_
+
+
+
+URI: [xsd:dateTime](http://www.w3.org/2001/XMLSchema#dateTime)
+
+* [base](https://w3id.org/linkml/base): XSDDateTime
+
+* [uri](https://w3id.org/linkml/uri): xsd:dateTime
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:dateTime |
+| native | rfs:datetime |
+| exact | schema:DateTime |
+
+
+

--- a/schema/generated/Decimal.md
+++ b/schema/generated/Decimal.md
@@ -1,0 +1,49 @@
+# Type: Decimal
+
+
+
+
+_A real number with arbitrary precision that conforms to the xsd:decimal specification_
+
+
+
+URI: [xsd:decimal](http://www.w3.org/2001/XMLSchema#decimal)
+
+* [base](https://w3id.org/linkml/base): Decimal
+
+* [uri](https://w3id.org/linkml/uri): xsd:decimal
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:decimal |
+| native | rfs:decimal |
+| broad | schema:Number |
+
+
+

--- a/schema/generated/Double.md
+++ b/schema/generated/Double.md
@@ -1,0 +1,49 @@
+# Type: Double
+
+
+
+
+_A real number that conforms to the xsd:double specification_
+
+
+
+URI: [xsd:double](http://www.w3.org/2001/XMLSchema#double)
+
+* [base](https://w3id.org/linkml/base): float
+
+* [uri](https://w3id.org/linkml/uri): xsd:double
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:double |
+| native | rfs:double |
+| close | schema:Float |
+
+
+

--- a/schema/generated/File.md
+++ b/schema/generated/File.md
@@ -1,0 +1,204 @@
+
+
+# Class: File
+
+
+
+URI: [rfs:File](https://framework.regen.network/schema/File)
+
+
+
+```mermaid
+erDiagram
+File {
+    string iri  
+    string name  
+    string description  
+    string credit  
+}
+FileLocation {
+    string wkt  
+}
+
+File ||--|o FileLocation : "location"
+
+```
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [iri](iri.md) | 1 <br/> [String](String.md) |  | direct |
+| [name](name.md) | 1 <br/> [String](String.md) |  | direct |
+| [description](description.md) | 0..1 <br/> [String](String.md) |  | direct |
+| [location](location.md) | 0..1 <br/> [FileLocation](FileLocation.md) |  | direct |
+| [credit](credit.md) | 0..1 <br/> [String](String.md) |  | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [ProjectPost](ProjectPost.md) | [files](files.md) | range | [File](File.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | rfs:File |
+| native | rfs:File |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: File
+from_schema: https://framework.regen.network/schema/
+attributes:
+  iri:
+    name: iri
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    identifier: true
+    domain_of:
+    - File
+    required: true
+  name:
+    name: name
+    from_schema: https://framework.regen.network/schema/
+    slot_uri: dcterms:title
+    domain_of:
+    - Project
+    - ProjectRole
+    - File
+    required: true
+  description:
+    name: description
+    from_schema: https://framework.regen.network/schema/
+    slot_uri: dcterms:description
+    domain_of:
+    - Project
+    - ProjectRole
+    - File
+  location:
+    name: location
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: geo:hasGeometry
+    domain_of:
+    - File
+    range: FileLocation
+  credit:
+    name: credit
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: dcterms:creator
+    domain_of:
+    - File
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: File
+from_schema: https://framework.regen.network/schema/
+attributes:
+  iri:
+    name: iri
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    identifier: true
+    alias: iri
+    owner: File
+    domain_of:
+    - File
+    range: string
+    required: true
+  name:
+    name: name
+    from_schema: https://framework.regen.network/schema/
+    slot_uri: dcterms:title
+    alias: name
+    owner: File
+    domain_of:
+    - Project
+    - ProjectRole
+    - File
+    range: string
+    required: true
+  description:
+    name: description
+    from_schema: https://framework.regen.network/schema/
+    slot_uri: dcterms:description
+    alias: description
+    owner: File
+    domain_of:
+    - Project
+    - ProjectRole
+    - File
+    range: string
+  location:
+    name: location
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: geo:hasGeometry
+    alias: location
+    owner: File
+    domain_of:
+    - File
+    range: FileLocation
+  credit:
+    name: credit
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: dcterms:creator
+    alias: credit
+    owner: File
+    domain_of:
+    - File
+    range: string
+
+```
+</details>

--- a/schema/generated/FileLocation.md
+++ b/schema/generated/FileLocation.md
@@ -1,0 +1,119 @@
+
+
+# Class: FileLocation
+
+
+
+URI: [geo:Geometry](http://www.opengis.net/ont/geosparql#Geometry)
+
+
+
+```mermaid
+erDiagram
+FileLocation {
+    string wkt  
+}
+
+
+
+```
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [wkt](wkt.md) | 0..1 <br/> [String](String.md) |  | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [File](File.md) | [location](location.md) | range | [FileLocation](FileLocation.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | geo:Geometry |
+| native | rfs:FileLocation |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: FileLocation
+from_schema: https://framework.regen.network/schema/
+attributes:
+  wkt:
+    name: wkt
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: geo:asWKT
+    domain_of:
+    - FileLocation
+class_uri: geo:Geometry
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: FileLocation
+from_schema: https://framework.regen.network/schema/
+attributes:
+  wkt:
+    name: wkt
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: geo:asWKT
+    alias: wkt
+    owner: FileLocation
+    domain_of:
+    - FileLocation
+    range: string
+class_uri: geo:Geometry
+
+```
+</details>

--- a/schema/generated/Float.md
+++ b/schema/generated/Float.md
@@ -1,0 +1,49 @@
+# Type: Float
+
+
+
+
+_A real number that conforms to the xsd:float specification_
+
+
+
+URI: [xsd:float](http://www.w3.org/2001/XMLSchema#float)
+
+* [base](https://w3id.org/linkml/base): float
+
+* [uri](https://w3id.org/linkml/uri): xsd:float
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:float |
+| native | rfs:float |
+| exact | schema:Float |
+
+
+

--- a/schema/generated/Integer.md
+++ b/schema/generated/Integer.md
@@ -1,0 +1,49 @@
+# Type: Integer
+
+
+
+
+_An integer_
+
+
+
+URI: [xsd:integer](http://www.w3.org/2001/XMLSchema#integer)
+
+* [base](https://w3id.org/linkml/base): int
+
+* [uri](https://w3id.org/linkml/uri): xsd:integer
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:integer |
+| native | rfs:integer |
+| exact | schema:Integer |
+
+
+

--- a/schema/generated/Jsonpath.md
+++ b/schema/generated/Jsonpath.md
@@ -1,0 +1,49 @@
+# Type: Jsonpath
+
+
+
+
+_A string encoding a JSON Path. The value of the string MUST conform to JSON Point syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded in tree form._
+
+
+
+URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+* [base](https://w3id.org/linkml/base): str
+
+* [uri](https://w3id.org/linkml/uri): xsd:string
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:string |
+| native | rfs:jsonpath |
+
+
+

--- a/schema/generated/Jsonpointer.md
+++ b/schema/generated/Jsonpointer.md
@@ -1,0 +1,49 @@
+# Type: Jsonpointer
+
+
+
+
+_A string encoding a JSON Pointer. The value of the string MUST conform to JSON Point syntax and SHOULD dereference to a valid object within the current instance document when encoded in tree form._
+
+
+
+URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+* [base](https://w3id.org/linkml/base): str
+
+* [uri](https://w3id.org/linkml/uri): xsd:string
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:string |
+| native | rfs:jsonpointer |
+
+
+

--- a/schema/generated/Ncname.md
+++ b/schema/generated/Ncname.md
@@ -1,0 +1,49 @@
+# Type: Ncname
+
+
+
+
+_Prefix part of CURIE_
+
+
+
+URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+* [base](https://w3id.org/linkml/base): NCName
+
+* [uri](https://w3id.org/linkml/uri): xsd:string
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:string |
+| native | rfs:ncname |
+
+
+

--- a/schema/generated/Nodeidentifier.md
+++ b/schema/generated/Nodeidentifier.md
@@ -1,0 +1,49 @@
+# Type: Nodeidentifier
+
+
+
+
+_A URI, CURIE or BNODE that represents a node in a model._
+
+
+
+URI: [shex:nonLiteral](http://www.w3.org/ns/shex#nonLiteral)
+
+* [base](https://w3id.org/linkml/base): NodeIdentifier
+
+* [uri](https://w3id.org/linkml/uri): shex:nonLiteral
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | shex:nonLiteral |
+| native | rfs:nodeidentifier |
+
+
+

--- a/schema/generated/Objectidentifier.md
+++ b/schema/generated/Objectidentifier.md
@@ -1,0 +1,53 @@
+# Type: Objectidentifier
+
+
+
+
+_A URI or CURIE that represents an object in the model._
+
+
+
+URI: [shex:iri](http://www.w3.org/ns/shex#iri)
+
+* [base](https://w3id.org/linkml/base): ElementIdentifier
+
+* [uri](https://w3id.org/linkml/uri): shex:iri
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Comments
+
+* Used for inheritance and type checking
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | shex:iri |
+| native | rfs:objectidentifier |
+
+
+

--- a/schema/generated/Project.md
+++ b/schema/generated/Project.md
@@ -1,0 +1,288 @@
+
+
+# Class: Project
+
+
+
+URI: [rfs:Project](https://framework.regen.network/schema/Project)
+
+
+
+```mermaid
+erDiagram
+Project {
+    string name  
+    string description  
+    uriorcurie id  
+    integer size  
+    string activity  
+    string start_date  
+    string end_date  
+    string project_type  
+    string project_verifier  
+}
+ProjectRole {
+    string name  
+    string description  
+    string url  
+    ProjectRoleTypes type  
+    string image  
+}
+ProjectSize {
+    string unit  
+    double numericValue  
+}
+
+Project ||--|o ProjectSize : "project_size"
+Project ||--|o ProjectRole : "project_developer"
+
+```
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [name](name.md) | 1 <br/> [String](String.md) | Name of the project | direct |
+| [description](description.md) | 0..1 <br/> [String](String.md) | Optional description of the project | direct |
+| [project_size](project_size.md) | 0..1 <br/> [ProjectSize](ProjectSize.md) |  | direct |
+| [project_developer](project_developer.md) | 0..1 <br/> [ProjectRole](ProjectRole.md) |  | direct |
+| [id](id.md) | 1 <br/> [Uriorcurie](Uriorcurie.md) |  | direct |
+| [size](size.md) | 0..1 <br/> [Integer](Integer.md) |  | direct |
+| [activity](activity.md) | 0..1 <br/> [String](String.md) |  | direct |
+| [start_date](start_date.md) | 0..1 <br/> [String](String.md) |  | direct |
+| [end_date](end_date.md) | 0..1 <br/> [String](String.md) |  | direct |
+| [project_type](project_type.md) | 0..1 <br/> [String](String.md) |  | direct |
+| [project_verifier](project_verifier.md) | 0..1 <br/> [String](String.md) |  | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | rfs:Project |
+| native | rfs:Project |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: Project
+from_schema: https://framework.regen.network/schema/
+slots:
+- name
+- description
+- project_size
+- project_developer
+attributes:
+  id:
+    name: id
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    identifier: true
+    domain_of:
+    - Project
+    range: uriorcurie
+    required: true
+  size:
+    name: size
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    domain_of:
+    - Project
+    range: integer
+  activity:
+    name: activity
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    domain_of:
+    - Project
+  start_date:
+    name: start_date
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    domain_of:
+    - Project
+  end_date:
+    name: end_date
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    domain_of:
+    - Project
+  project_type:
+    name: project_type
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    domain_of:
+    - Project
+  project_verifier:
+    name: project_verifier
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    domain_of:
+    - Project
+class_uri: rfs:Project
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: Project
+from_schema: https://framework.regen.network/schema/
+attributes:
+  id:
+    name: id
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    identifier: true
+    alias: id
+    owner: Project
+    domain_of:
+    - Project
+    range: uriorcurie
+    required: true
+  size:
+    name: size
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    alias: size
+    owner: Project
+    domain_of:
+    - Project
+    range: integer
+  activity:
+    name: activity
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    alias: activity
+    owner: Project
+    domain_of:
+    - Project
+    range: string
+  start_date:
+    name: start_date
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    alias: start_date
+    owner: Project
+    domain_of:
+    - Project
+    range: string
+  end_date:
+    name: end_date
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    alias: end_date
+    owner: Project
+    domain_of:
+    - Project
+    range: string
+  project_type:
+    name: project_type
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    alias: project_type
+    owner: Project
+    domain_of:
+    - Project
+    range: string
+  project_verifier:
+    name: project_verifier
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    alias: project_verifier
+    owner: Project
+    domain_of:
+    - Project
+    range: string
+  name:
+    name: name
+    description: Name of the project.
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: schema:name
+    alias: name
+    owner: Project
+    domain_of:
+    - Project
+    - ProjectRole
+    - File
+    range: string
+    required: true
+  description:
+    name: description
+    description: Optional description of the project.
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: schema:description
+    alias: description
+    owner: Project
+    domain_of:
+    - Project
+    - ProjectRole
+    - File
+    range: string
+  project_size:
+    name: project_size
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    alias: project_size
+    owner: Project
+    domain_of:
+    - Project
+    range: ProjectSize
+    inlined: false
+  project_developer:
+    name: project_developer
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    alias: project_developer
+    owner: Project
+    domain_of:
+    - Project
+    range: ProjectRole
+    inlined: false
+class_uri: rfs:Project
+
+```
+</details>

--- a/schema/generated/ProjectPost.md
+++ b/schema/generated/ProjectPost.md
@@ -1,0 +1,168 @@
+
+
+# Class: ProjectPost
+
+
+
+URI: [rfs:ProjectPost](https://framework.regen.network/schema/ProjectPost)
+
+
+
+```mermaid
+erDiagram
+ProjectPost {
+    string title  
+    string comment  
+}
+File {
+    string iri  
+    string name  
+    string description  
+    string credit  
+}
+FileLocation {
+    string wkt  
+}
+
+ProjectPost ||--}o File : "files"
+File ||--|o FileLocation : "location"
+
+```
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [title](title.md) | 1 <br/> [String](String.md) |  | direct |
+| [comment](comment.md) | 0..1 <br/> [String](String.md) |  | direct |
+| [files](files.md) | * <br/> [File](File.md) |  | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | rfs:ProjectPost |
+| native | rfs:ProjectPost |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: ProjectPost
+from_schema: https://framework.regen.network/schema/
+attributes:
+  title:
+    name: title
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: dcterms:title
+    domain_of:
+    - ProjectPost
+    required: true
+  comment:
+    name: comment
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: dcterms:description
+    domain_of:
+    - ProjectPost
+  files:
+    name: files
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: dcterms:references
+    list_elements_ordered: true
+    domain_of:
+    - ProjectPost
+    range: File
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: ProjectPost
+from_schema: https://framework.regen.network/schema/
+attributes:
+  title:
+    name: title
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: dcterms:title
+    alias: title
+    owner: ProjectPost
+    domain_of:
+    - ProjectPost
+    range: string
+    required: true
+  comment:
+    name: comment
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: dcterms:description
+    alias: comment
+    owner: ProjectPost
+    domain_of:
+    - ProjectPost
+    range: string
+  files:
+    name: files
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: dcterms:references
+    list_elements_ordered: true
+    alias: files
+    owner: ProjectPost
+    domain_of:
+    - ProjectPost
+    range: File
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+
+```
+</details>

--- a/schema/generated/ProjectRole.md
+++ b/schema/generated/ProjectRole.md
@@ -1,0 +1,185 @@
+
+
+# Class: ProjectRole
+
+
+
+URI: [rfs:ProjectRole](https://framework.regen.network/schema/ProjectRole)
+
+
+
+```mermaid
+erDiagram
+ProjectRole {
+    string name  
+    string description  
+    string url  
+    ProjectRoleTypes type  
+    string image  
+}
+
+
+
+```
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [name](name.md) | 1 <br/> [String](String.md) | Name of the project | direct |
+| [description](description.md) | 0..1 <br/> [String](String.md) | Optional description of the project | direct |
+| [url](url.md) | 0..1 <br/> [String](String.md) |  | direct |
+| [type](type.md) | 1 <br/> [ProjectRoleTypes](ProjectRoleTypes.md) |  | direct |
+| [image](image.md) | 0..1 <br/> [String](String.md) |  | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Project](Project.md) | [project_developer](project_developer.md) | range | [ProjectRole](ProjectRole.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | rfs:ProjectRole |
+| native | rfs:ProjectRole |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: ProjectRole
+from_schema: https://framework.regen.network/schema/
+slots:
+- name
+- description
+- url
+attributes:
+  type:
+    name: type
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: rfs:ProjectRoleType
+    domain_of:
+    - ProjectRole
+    range: ProjectRoleTypes
+    required: true
+  image:
+    name: image
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: schema:image
+    domain_of:
+    - ProjectRole
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: ProjectRole
+from_schema: https://framework.regen.network/schema/
+attributes:
+  type:
+    name: type
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: rfs:ProjectRoleType
+    alias: type
+    owner: ProjectRole
+    domain_of:
+    - ProjectRole
+    range: ProjectRoleTypes
+    required: true
+  image:
+    name: image
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: schema:image
+    alias: image
+    owner: ProjectRole
+    domain_of:
+    - ProjectRole
+    range: string
+  name:
+    name: name
+    description: Name of the project.
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: schema:name
+    alias: name
+    owner: ProjectRole
+    domain_of:
+    - Project
+    - ProjectRole
+    - File
+    range: string
+    required: true
+  description:
+    name: description
+    description: Optional description of the project.
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: schema:description
+    alias: description
+    owner: ProjectRole
+    domain_of:
+    - Project
+    - ProjectRole
+    - File
+    range: string
+  url:
+    name: url
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    alias: url
+    owner: ProjectRole
+    domain_of:
+    - ProjectRole
+    range: string
+
+```
+</details>

--- a/schema/generated/ProjectRoleTypes.md
+++ b/schema/generated/ProjectRoleTypes.md
@@ -1,0 +1,62 @@
+# Enum: ProjectRoleTypes
+
+
+
+URI: [ProjectRoleTypes](ProjectRoleTypes.md)
+
+## Permissible Values
+
+| Value | Meaning | Description |
+| --- | --- | --- |
+| individual | rfs:Individual |  |
+| organization | rfs:Organization |  |
+
+
+
+
+## Slots
+
+| Name | Description |
+| ---  | --- |
+| [type](type.md) |  |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: ProjectRoleTypes
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+permissible_values:
+  individual:
+    text: individual
+    meaning: rfs:Individual
+  organization:
+    text: organization
+    meaning: rfs:Organization
+
+```
+</details>

--- a/schema/generated/ProjectSize.md
+++ b/schema/generated/ProjectSize.md
@@ -1,0 +1,143 @@
+
+
+# Class: ProjectSize
+
+
+
+URI: [rfs:ProjectSize](https://framework.regen.network/schema/ProjectSize)
+
+
+
+```mermaid
+erDiagram
+ProjectSize {
+    string unit  
+    double numericValue  
+}
+
+
+
+```
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [unit](unit.md) | 1 <br/> [String](String.md) |  | direct |
+| [numericValue](numericValue.md) | 1 <br/> [Double](Double.md) |  | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Project](Project.md) | [project_size](project_size.md) | range | [ProjectSize](ProjectSize.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | rfs:ProjectSize |
+| native | rfs:ProjectSize |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: ProjectSize
+from_schema: https://framework.regen.network/schema/
+attributes:
+  unit:
+    name: unit
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: qudt:unit
+    domain_of:
+    - ProjectSize
+    required: true
+  numericValue:
+    name: numericValue
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: qudt:numericValue
+    domain_of:
+    - ProjectSize
+    range: double
+    required: true
+class_uri: rfs:ProjectSize
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: ProjectSize
+from_schema: https://framework.regen.network/schema/
+attributes:
+  unit:
+    name: unit
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: qudt:unit
+    alias: unit
+    owner: ProjectSize
+    domain_of:
+    - ProjectSize
+    range: string
+    required: true
+  numericValue:
+    name: numericValue
+    from_schema: https://framework.regen.network/schema/
+    rank: 1000
+    slot_uri: qudt:numericValue
+    alias: numericValue
+    owner: ProjectSize
+    domain_of:
+    - ProjectSize
+    range: double
+    required: true
+class_uri: rfs:ProjectSize
+
+```
+</details>

--- a/schema/generated/Schemas.md
+++ b/schema/generated/Schemas.md
@@ -1,0 +1,6 @@
+# Schemas
+
+None
+
+URI: https://framework.regen.network/schema/
+

--- a/schema/generated/Sparqlpath.md
+++ b/schema/generated/Sparqlpath.md
@@ -1,0 +1,49 @@
+# Type: Sparqlpath
+
+
+
+
+_A string encoding a SPARQL Property Path. The value of the string MUST conform to SPARQL syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded as RDF._
+
+
+
+URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+* [base](https://w3id.org/linkml/base): str
+
+* [uri](https://w3id.org/linkml/uri): xsd:string
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:string |
+| native | rfs:sparqlpath |
+
+
+

--- a/schema/generated/String.md
+++ b/schema/generated/String.md
@@ -1,0 +1,49 @@
+# Type: String
+
+
+
+
+_A character string_
+
+
+
+URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+* [base](https://w3id.org/linkml/base): str
+
+* [uri](https://w3id.org/linkml/uri): xsd:string
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:string |
+| native | rfs:string |
+| exact | schema:Text |
+
+
+

--- a/schema/generated/Time.md
+++ b/schema/generated/Time.md
@@ -1,0 +1,50 @@
+# Type: Time
+
+
+
+
+_A time object represents a (local) time of day, independent of any particular day_
+
+
+
+URI: [xsd:time](http://www.w3.org/2001/XMLSchema#time)
+
+* [base](https://w3id.org/linkml/base): XSDTime
+
+* [uri](https://w3id.org/linkml/uri): xsd:time
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:time |
+| native | rfs:time |
+| exact | schema:Time |
+
+
+

--- a/schema/generated/Uri.md
+++ b/schema/generated/Uri.md
@@ -1,0 +1,54 @@
+# Type: Uri
+
+
+
+
+_a complete URI_
+
+
+
+URI: [xsd:anyURI](http://www.w3.org/2001/XMLSchema#anyURI)
+
+* [base](https://w3id.org/linkml/base): URI
+
+* [uri](https://w3id.org/linkml/uri): xsd:anyURI
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Comments
+
+* in RDF serializations a slot with range of uri is treated as a literal or type xsd:anyURI unless it is an identifier or a reference to an identifier, in which case it is translated directly to a node
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:anyURI |
+| native | rfs:uri |
+| close | schema:URL |
+
+
+

--- a/schema/generated/Uriorcurie.md
+++ b/schema/generated/Uriorcurie.md
@@ -1,0 +1,49 @@
+# Type: Uriorcurie
+
+
+
+
+_a URI or a CURIE_
+
+
+
+URI: [xsd:anyURI](http://www.w3.org/2001/XMLSchema#anyURI)
+
+* [base](https://w3id.org/linkml/base): URIorCURIE
+
+* [uri](https://w3id.org/linkml/uri): xsd:anyURI
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:anyURI |
+| native | rfs:uriorcurie |
+
+
+

--- a/schema/generated/activity.md
+++ b/schema/generated/activity.md
@@ -1,0 +1,75 @@
+
+
+# Slot: activity
+
+URI: [rfs:activity](https://framework.regen.network/schema/activity)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Project](Project.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | rfs:activity |
+| native | rfs:activity |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: activity
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+alias: activity
+owner: Project
+domain_of:
+- Project
+range: string
+
+```
+</details>

--- a/schema/generated/comment.md
+++ b/schema/generated/comment.md
@@ -1,0 +1,76 @@
+
+
+# Slot: comment
+
+URI: [dcterms:description](http://purl.org/dc/terms/description)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [ProjectPost](ProjectPost.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | dcterms:description |
+| native | rfs:comment |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: comment
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+slot_uri: dcterms:description
+alias: comment
+owner: ProjectPost
+domain_of:
+- ProjectPost
+range: string
+
+```
+</details>

--- a/schema/generated/credit.md
+++ b/schema/generated/credit.md
@@ -1,0 +1,76 @@
+
+
+# Slot: credit
+
+URI: [dcterms:creator](http://purl.org/dc/terms/creator)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [File](File.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | dcterms:creator |
+| native | rfs:credit |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: credit
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+slot_uri: dcterms:creator
+alias: credit
+owner: File
+domain_of:
+- File
+range: string
+
+```
+</details>

--- a/schema/generated/description.md
+++ b/schema/generated/description.md
@@ -1,0 +1,85 @@
+
+
+# Slot: description
+
+
+_Optional description of the project._
+
+
+
+URI: [schema:description](http://schema.org/description)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Project](Project.md) |  |  no  |
+| [File](File.md) |  |  no  |
+| [ProjectRole](ProjectRole.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | schema:description |
+| native | rfs:description |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: description
+description: Optional description of the project.
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+slot_uri: schema:description
+alias: description
+domain_of:
+- Project
+- ProjectRole
+- File
+range: string
+
+```
+</details>

--- a/schema/generated/end_date.md
+++ b/schema/generated/end_date.md
@@ -1,0 +1,75 @@
+
+
+# Slot: end_date
+
+URI: [rfs:end_date](https://framework.regen.network/schema/end_date)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Project](Project.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | rfs:end_date |
+| native | rfs:end_date |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: end_date
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+alias: end_date
+owner: Project
+domain_of:
+- Project
+range: string
+
+```
+</details>

--- a/schema/generated/files.md
+++ b/schema/generated/files.md
@@ -1,0 +1,82 @@
+
+
+# Slot: files
+
+URI: [dcterms:references](http://purl.org/dc/terms/references)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [ProjectPost](ProjectPost.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [File](File.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | dcterms:references |
+| native | rfs:files |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: files
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+slot_uri: dcterms:references
+list_elements_ordered: true
+alias: files
+owner: ProjectPost
+domain_of:
+- ProjectPost
+range: File
+multivalued: true
+inlined: true
+inlined_as_list: true
+
+```
+</details>

--- a/schema/generated/id.md
+++ b/schema/generated/id.md
@@ -1,0 +1,79 @@
+
+
+# Slot: id
+
+URI: [rfs:id](https://framework.regen.network/schema/id)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Project](Project.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Uriorcurie](Uriorcurie.md)
+
+* Required: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | rfs:id |
+| native | rfs:id |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: id
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+identifier: true
+alias: id
+owner: Project
+domain_of:
+- Project
+range: uriorcurie
+required: true
+
+```
+</details>

--- a/schema/generated/image.md
+++ b/schema/generated/image.md
@@ -1,0 +1,76 @@
+
+
+# Slot: image
+
+URI: [schema:image](http://schema.org/image)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [ProjectRole](ProjectRole.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | schema:image |
+| native | rfs:image |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: image
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+slot_uri: schema:image
+alias: image
+owner: ProjectRole
+domain_of:
+- ProjectRole
+range: string
+
+```
+</details>

--- a/schema/generated/index.md
+++ b/schema/generated/index.md
@@ -1,0 +1,88 @@
+# Schemas
+
+
+
+URI: https://framework.regen.network/schema/
+
+Name: Schemas
+
+
+
+## Classes
+
+| Class | Description |
+| --- | --- |
+| [File](File.md) | None |
+| [FileLocation](FileLocation.md) | None |
+| [Project](Project.md) | None |
+| [ProjectPost](ProjectPost.md) | None |
+| [ProjectRole](ProjectRole.md) | None |
+| [ProjectSize](ProjectSize.md) | None |
+
+
+
+## Slots
+
+| Slot | Description |
+| --- | --- |
+| [activity](activity.md) |  |
+| [comment](comment.md) |  |
+| [credit](credit.md) |  |
+| [description](description.md) | Optional description of the project |
+| [end_date](end_date.md) |  |
+| [files](files.md) |  |
+| [id](id.md) |  |
+| [image](image.md) |  |
+| [iri](iri.md) |  |
+| [location](location.md) |  |
+| [name](name.md) | Name of the project |
+| [numericValue](numericValue.md) |  |
+| [project_developer](project_developer.md) |  |
+| [project_size](project_size.md) |  |
+| [project_type](project_type.md) |  |
+| [project_verifier](project_verifier.md) |  |
+| [size](size.md) |  |
+| [start_date](start_date.md) |  |
+| [title](title.md) |  |
+| [type](type.md) |  |
+| [unit](unit.md) |  |
+| [url](url.md) |  |
+| [wkt](wkt.md) |  |
+
+
+## Enumerations
+
+| Enumeration | Description |
+| --- | --- |
+| [ProjectRoleTypes](ProjectRoleTypes.md) |  |
+
+
+## Types
+
+| Type | Description |
+| --- | --- |
+| [Boolean](Boolean.md) | A binary (true or false) value |
+| [Curie](Curie.md) | a compact URI |
+| [Date](Date.md) | a date (year, month and day) in an idealized calendar |
+| [DateOrDatetime](DateOrDatetime.md) | Either a date or a datetime |
+| [Datetime](Datetime.md) | The combination of a date and time |
+| [Decimal](Decimal.md) | A real number with arbitrary precision that conforms to the xsd:decimal speci... |
+| [Double](Double.md) | A real number that conforms to the xsd:double specification |
+| [Float](Float.md) | A real number that conforms to the xsd:float specification |
+| [Integer](Integer.md) | An integer |
+| [Jsonpath](Jsonpath.md) | A string encoding a JSON Path |
+| [Jsonpointer](Jsonpointer.md) | A string encoding a JSON Pointer |
+| [Ncname](Ncname.md) | Prefix part of CURIE |
+| [Nodeidentifier](Nodeidentifier.md) | A URI, CURIE or BNODE that represents a node in a model |
+| [Objectidentifier](Objectidentifier.md) | A URI or CURIE that represents an object in the model |
+| [Sparqlpath](Sparqlpath.md) | A string encoding a SPARQL Property Path |
+| [String](String.md) | A character string |
+| [Time](Time.md) | A time object represents a (local) time of day, independent of any particular... |
+| [Uri](Uri.md) | a complete URI |
+| [Uriorcurie](Uriorcurie.md) | a URI or a CURIE |
+
+
+## Subsets
+
+| Subset | Description |
+| --- | --- |

--- a/schema/generated/iri.md
+++ b/schema/generated/iri.md
@@ -1,0 +1,79 @@
+
+
+# Slot: iri
+
+URI: [rfs:iri](https://framework.regen.network/schema/iri)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [File](File.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+* Required: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | rfs:iri |
+| native | rfs:iri |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: iri
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+identifier: true
+alias: iri
+owner: File
+domain_of:
+- File
+range: string
+required: true
+
+```
+</details>

--- a/schema/generated/location.md
+++ b/schema/generated/location.md
@@ -1,0 +1,76 @@
+
+
+# Slot: location
+
+URI: [geo:hasGeometry](http://www.opengis.net/ont/geosparql#hasGeometry)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [File](File.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [FileLocation](FileLocation.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | geo:hasGeometry |
+| native | rfs:location |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: location
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+slot_uri: geo:hasGeometry
+alias: location
+owner: File
+domain_of:
+- File
+range: FileLocation
+
+```
+</details>

--- a/schema/generated/name.md
+++ b/schema/generated/name.md
@@ -1,0 +1,88 @@
+
+
+# Slot: name
+
+
+_Name of the project._
+
+
+
+URI: [schema:name](http://schema.org/name)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Project](Project.md) |  |  no  |
+| [File](File.md) |  |  no  |
+| [ProjectRole](ProjectRole.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+* Required: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | schema:name |
+| native | rfs:name |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: name
+description: Name of the project.
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+slot_uri: schema:name
+alias: name
+domain_of:
+- Project
+- ProjectRole
+- File
+range: string
+required: true
+
+```
+</details>

--- a/schema/generated/numericValue.md
+++ b/schema/generated/numericValue.md
@@ -1,0 +1,79 @@
+
+
+# Slot: numericValue
+
+URI: [qudt:numericValue](http://qudt.org/schema/qudt/numericValue)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [ProjectSize](ProjectSize.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Double](Double.md)
+
+* Required: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | qudt:numericValue |
+| native | rfs:numericValue |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: numericValue
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+slot_uri: qudt:numericValue
+alias: numericValue
+owner: ProjectSize
+domain_of:
+- ProjectSize
+range: double
+required: true
+
+```
+</details>

--- a/schema/generated/project_developer.md
+++ b/schema/generated/project_developer.md
@@ -1,0 +1,75 @@
+
+
+# Slot: project_developer
+
+URI: [rfs:project_developer](https://framework.regen.network/schema/project_developer)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Project](Project.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [ProjectRole](ProjectRole.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | rfs:project_developer |
+| native | rfs:project_developer |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: project_developer
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+alias: project_developer
+domain_of:
+- Project
+range: ProjectRole
+inlined: false
+
+```
+</details>

--- a/schema/generated/project_size.md
+++ b/schema/generated/project_size.md
@@ -1,0 +1,75 @@
+
+
+# Slot: project_size
+
+URI: [rfs:project_size](https://framework.regen.network/schema/project_size)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Project](Project.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [ProjectSize](ProjectSize.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | rfs:project_size |
+| native | rfs:project_size |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: project_size
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+alias: project_size
+domain_of:
+- Project
+range: ProjectSize
+inlined: false
+
+```
+</details>

--- a/schema/generated/project_type.md
+++ b/schema/generated/project_type.md
@@ -1,0 +1,75 @@
+
+
+# Slot: project_type
+
+URI: [rfs:project_type](https://framework.regen.network/schema/project_type)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Project](Project.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | rfs:project_type |
+| native | rfs:project_type |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: project_type
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+alias: project_type
+owner: Project
+domain_of:
+- Project
+range: string
+
+```
+</details>

--- a/schema/generated/project_verifier.md
+++ b/schema/generated/project_verifier.md
@@ -1,0 +1,75 @@
+
+
+# Slot: project_verifier
+
+URI: [rfs:project_verifier](https://framework.regen.network/schema/project_verifier)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Project](Project.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | rfs:project_verifier |
+| native | rfs:project_verifier |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: project_verifier
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+alias: project_verifier
+owner: Project
+domain_of:
+- Project
+range: string
+
+```
+</details>

--- a/schema/generated/size.md
+++ b/schema/generated/size.md
@@ -1,0 +1,75 @@
+
+
+# Slot: size
+
+URI: [rfs:size](https://framework.regen.network/schema/size)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Project](Project.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Integer](Integer.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | rfs:size |
+| native | rfs:size |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: size
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+alias: size
+owner: Project
+domain_of:
+- Project
+range: integer
+
+```
+</details>

--- a/schema/generated/start_date.md
+++ b/schema/generated/start_date.md
@@ -1,0 +1,75 @@
+
+
+# Slot: start_date
+
+URI: [rfs:start_date](https://framework.regen.network/schema/start_date)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Project](Project.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | rfs:start_date |
+| native | rfs:start_date |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: start_date
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+alias: start_date
+owner: Project
+domain_of:
+- Project
+range: string
+
+```
+</details>

--- a/schema/generated/title.md
+++ b/schema/generated/title.md
@@ -1,0 +1,79 @@
+
+
+# Slot: title
+
+URI: [dcterms:title](http://purl.org/dc/terms/title)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [ProjectPost](ProjectPost.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+* Required: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | dcterms:title |
+| native | rfs:title |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: title
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+slot_uri: dcterms:title
+alias: title
+owner: ProjectPost
+domain_of:
+- ProjectPost
+range: string
+required: true
+
+```
+</details>

--- a/schema/generated/type.md
+++ b/schema/generated/type.md
@@ -1,0 +1,79 @@
+
+
+# Slot: type
+
+URI: [rfs:ProjectRoleType](https://framework.regen.network/schema/ProjectRoleType)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [ProjectRole](ProjectRole.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [ProjectRoleTypes](ProjectRoleTypes.md)
+
+* Required: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | rfs:ProjectRoleType |
+| native | rfs:type |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: type
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+slot_uri: rfs:ProjectRoleType
+alias: type
+owner: ProjectRole
+domain_of:
+- ProjectRole
+range: ProjectRoleTypes
+required: true
+
+```
+</details>

--- a/schema/generated/unit.md
+++ b/schema/generated/unit.md
@@ -1,0 +1,79 @@
+
+
+# Slot: unit
+
+URI: [qudt:unit](http://qudt.org/schema/qudt/unit)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [ProjectSize](ProjectSize.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+* Required: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | qudt:unit |
+| native | rfs:unit |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: unit
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+slot_uri: qudt:unit
+alias: unit
+owner: ProjectSize
+domain_of:
+- ProjectSize
+range: string
+required: true
+
+```
+</details>

--- a/schema/generated/url.md
+++ b/schema/generated/url.md
@@ -1,0 +1,74 @@
+
+
+# Slot: url
+
+URI: [rfs:url](https://framework.regen.network/schema/url)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [ProjectRole](ProjectRole.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | rfs:url |
+| native | rfs:url |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: url
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+alias: url
+domain_of:
+- ProjectRole
+range: string
+
+```
+</details>

--- a/schema/generated/wkt.md
+++ b/schema/generated/wkt.md
@@ -1,0 +1,76 @@
+
+
+# Slot: wkt
+
+URI: [geo:asWKT](http://www.opengis.net/ont/geosparql#asWKT)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [FileLocation](FileLocation.md) |  |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://framework.regen.network/schema/
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | geo:asWKT |
+| native | rfs:wkt |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: wkt
+from_schema: https://framework.regen.network/schema/
+rank: 1000
+slot_uri: geo:asWKT
+alias: wkt
+owner: FileLocation
+domain_of:
+- FileLocation
+range: string
+
+```
+</details>

--- a/schema/src/project-post.yaml
+++ b/schema/src/project-post.yaml
@@ -1,0 +1,45 @@
+id: https://framework.regen.network/schema/project-post
+name: project-post
+prefixes:
+  linkml: https://w3id.org/linkml/
+  dcterms: http://purl.org/dc/terms/
+  geo: http://www.opengis.net/ont/geosparql#
+  rfs: https://framework.regen.network/schema/
+imports:
+  - linkml:types
+default_range: string
+default_prefix: rfs
+
+classes:
+  ProjectPost:
+    attributes:
+      title:
+        required: true
+        slot_uri: dcterms:title
+      comment:
+        slot_uri: dcterms:description
+      files:
+        range: File
+        slot_uri: dcterms:references
+        multivalued: true
+        inlined_as_list: true
+        list_elements_ordered: true
+  File:
+    attributes:
+      iri:
+        identifier: true
+      name:
+        required: true
+        slot_uri: dcterms:title
+      description:
+        slot_uri: dcterms:description
+      location:
+        range: FileLocation
+        slot_uri: geo:hasGeometry
+      credit:
+        slot_uri: dcterms:creator
+  FileLocation:
+    class_uri: geo:Geometry
+    attributes:
+      wkt:
+        slot_uri: geo:asWKT

--- a/schema/src/project.yaml
+++ b/schema/src/project.yaml
@@ -1,0 +1,80 @@
+id: https://framework.regen.network/schema/Project
+name: Project
+prefixes:
+  linkml: https://w3id.org/linkml/
+  rfs: https://framework.regen.network/schema/
+  schema: http://schema.org/
+  qudt: http://qudt.org/schema/qudt/
+  unit: http://qudt.org/vocab/unit/
+imports:
+  - linkml:types
+default_curi_maps:
+  - semweb_context
+default_prefix: rfs
+default_range: string
+
+classes:
+  Project:
+    class_uri: rfs:Project
+    slots:
+      - name
+      - description
+      - project_size
+      - project_developer
+    attributes:
+      id:
+        range: uriorcurie
+        identifier: true
+      size:
+        range: integer
+      activity:
+      start_date:
+      end_date:
+      project_type:
+      project_verifier:
+  ProjectSize:
+    class_uri: rfs:ProjectSize
+    attributes:
+      unit:
+        slot_uri: qudt:unit
+        required: true
+      numericValue:
+        range: double
+        slot_uri: qudt:numericValue
+        required: true
+  ProjectRole:
+    slots:
+      - name
+      - description
+      - url
+    attributes:
+      type:
+        range: ProjectRoleTypes
+        slot_uri: rfs:ProjectRoleType
+        required: true
+      image:
+        slot_uri: schema:image
+
+slots:
+  name:
+    required: true
+    description: Name of the project.
+    slot_uri: schema:name
+  description:
+    description: Optional description of the project.
+    slot_uri: schema:description
+  url:
+  project_size:
+    range: ProjectSize
+    inlined: false
+  project_developer:
+    range: ProjectRole
+    inlined: false
+
+enums:
+  ProjectRoleTypes:
+    permissible_values:
+      individual:
+        meaning: rfs:Individual
+      organization:
+        meaning: rfs:Organization

--- a/schema/src/schemas.yaml
+++ b/schema/src/schemas.yaml
@@ -1,0 +1,16 @@
+id: https://framework.regen.network/schema/
+name: Schemas
+prefixes:
+  linkml: https://w3id.org/linkml/
+  rfs: https://framework.regen.network/schema/
+  schema: http://schema.org/
+  qudt: http://qudt.org/schema/qudt/
+  unit: http://qudt.org/vocab/unit/
+imports:
+  - linkml:types
+  - project
+  - project-post
+default_curi_maps:
+  - semweb_context
+default_prefix: rfs
+default_range: string

--- a/src/components/sidebar/Sidebar.astro
+++ b/src/components/sidebar/Sidebar.astro
@@ -15,9 +15,9 @@ const schemas = [
 ">
     <nav>
         <ul class="flex flex-col gap-4">
-            <List collection={impacts} path="/impact" heading="Impacts"/>
-            <List collection={activities} path="/activity" heading="Activities"/>
-            <List collection={ecosystems} path="/environment-type" heading="Environment Type"/>
+            <List collection={impacts} path="/taxonomy/impact" heading="Impacts"/>
+            <List collection={activities} path="/taxonomy/activity" heading="Activities"/>
+            <List collection={ecosystems} path="/taxonomy/environment-type" heading="Environment Type"/>
             <List collection={schemas} path="/schema" heading="Schemas"/>
         </ul>
     </nav>

--- a/src/components/sidebar/Sidebar.astro
+++ b/src/components/sidebar/Sidebar.astro
@@ -4,6 +4,10 @@ import {getCollection} from 'astro:content';
 const impacts = await getCollection('impact');
 const ecosystems = await getCollection('environment-type');
 const activities = await getCollection('activity');
+const schemas = [
+    { slug: 'Project.md', data: {title: 'Project'} },
+    { slug: 'ProjectPost.md', data: {title: 'Project Post'} },
+]
 ---
 <div id="menu"
      class="w-60 border-grey-200 p-4 overflow-y-auto
@@ -14,6 +18,7 @@ const activities = await getCollection('activity');
             <List collection={impacts} path="/impact" heading="Impacts"/>
             <List collection={activities} path="/activity" heading="Activities"/>
             <List collection={ecosystems} path="/environment-type" heading="Environment Type"/>
+            <List collection={schemas} path="/schema" heading="Schemas"/>
         </ul>
     </nav>
 </div>

--- a/src/components/sidebar/Sidebar.list.astro
+++ b/src/components/sidebar/Sidebar.list.astro
@@ -2,9 +2,10 @@
 import Link from './Sidebar.link.astro'
 const {collection, path, heading} = Astro.props
 const {pathname} = Astro.url
+const open = pathname.includes(path);
 ---
 <li>
-    <details open>
+    <details {...(open ? {open} : {})}>
         <summary data-current={path == pathname} class="data-[current]:bg-brand-300 rounded-md px-2 py-1">
             <Link href={path}
                   className="p-1 text-lg font-bold">{heading}

--- a/src/pages/schema/[...slug].astro
+++ b/src/pages/schema/[...slug].astro
@@ -1,11 +1,12 @@
 ---
+import type {MarkdownInstance} from "astro";
 import MainLayout from "../../layouts/MainLayout.astro";
 export async function getStaticPaths() {
-    const schemas = await Astro.glob('../../../schema/generated/*.md');
+    const schemas: MarkdownInstance<{}>[] = await Astro.glob('../../../schema/generated/*.md');
     return schemas.map((entry) => {
         const file = entry.file;
         let filename = file.split('/').pop();
-        let title = filename.slice(0, -3);
+        let title = filename?.slice(0, -3);
 
         // Make the generated index.md the root path.
         if (filename === 'index.md') {

--- a/src/pages/schema/[...slug].astro
+++ b/src/pages/schema/[...slug].astro
@@ -6,18 +6,11 @@ export async function getStaticPaths() {
     return schemas.map((entry) => {
         const file = entry.file;
         let filename = file.split('/').pop();
-        let title, slug = filename?.slice(0, -3);
+        let slug = filename?.slice(0, -3);
 
-        // Make the generated index.md the root path.
-        if (filename === 'index.md') {
-            slug = undefined;
-            title = 'Schemas';
-        }
-
-        // For now, this makes it easier to navigate while testing.
         return {
             params: {slug},
-            props: {entry, title},
+            props: {entry, title: slug},
         }
     })
 }

--- a/src/pages/schema/[...slug].astro
+++ b/src/pages/schema/[...slug].astro
@@ -6,18 +6,17 @@ export async function getStaticPaths() {
     return schemas.map((entry) => {
         const file = entry.file;
         let filename = file.split('/').pop();
-        let title = filename?.slice(0, -3);
+        let title, slug = filename?.slice(0, -3);
 
         // Make the generated index.md the root path.
         if (filename === 'index.md') {
-            filename = undefined;
+            slug = undefined;
             title = 'Schemas';
         }
 
-        // @TODO: don't keep .md in the slug path.
         // For now, this makes it easier to navigate while testing.
         return {
-            params: {slug: filename},
+            params: {slug},
             props: {entry, title},
         }
     })

--- a/src/pages/schema/[...slug].astro
+++ b/src/pages/schema/[...slug].astro
@@ -1,0 +1,28 @@
+---
+import MainLayout from "../../layouts/MainLayout.astro";
+export async function getStaticPaths() {
+    const schemas = await Astro.glob('../../../schema/generated/*.md');
+    return schemas.map((entry) => {
+        const file = entry.file;
+        let filename = file.split('/').pop();
+        let title = filename.slice(0, -3);
+
+        // Make the generated index.md the root path.
+        if (filename === 'index.md') {
+            filename = undefined;
+            title = 'Schemas';
+        }
+
+        // @TODO: don't keep .md in the slug path.
+        // For now, this makes it easier to navigate while testing.
+        return {
+            params: {slug: filename},
+            props: {entry, title},
+        }
+    })
+}
+const {entry, title} = Astro.props;
+---
+<MainLayout title={`${title} | Schema`}>
+    <entry.Content/>
+</MainLayout>

--- a/src/pages/taxonomy/activity/[...slug].astro
+++ b/src/pages/taxonomy/activity/[...slug].astro
@@ -1,8 +1,8 @@
 ---
 import {getCollection} from 'astro:content';
-import MainLayout from "../../layouts/MainLayout.astro";
+import MainLayout from "../../../layouts/MainLayout.astro";
 export async function getStaticPaths() {
-    const entries = await getCollection('impact');
+    const entries = await getCollection('activity');
     return entries.map(entry => ({
         params: {slug: entry.slug}, props: {entry},
     }));
@@ -10,7 +10,7 @@ export async function getStaticPaths() {
 const {entry} = Astro.props;
 const {Content} = await entry.render();
 ---
-<MainLayout title={`${entry.data.title} | Impact`}>
+<MainLayout title={`${entry.data.title} | Activity`}>
     <h1 data-pagefind-meta="title">{entry.data.title}</h1>
     <Content/>
 </MainLayout>

--- a/src/pages/taxonomy/activity/index.mdx
+++ b/src/pages/taxonomy/activity/index.mdx
@@ -1,9 +1,9 @@
 ---
-layout: ../../layouts/MainLayout.astro
+layout: ../../../layouts/MainLayout.astro
 title: Activity
 ---
 
-import TaxonomyTable from '../../components/taxonomy/TaxonomyTable.astro'
+import TaxonomyTable from '../../../components/taxonomy/TaxonomyTable.astro'
 
 # Activity Taxonomy
 

--- a/src/pages/taxonomy/environment-type/[...slug].astro
+++ b/src/pages/taxonomy/environment-type/[...slug].astro
@@ -1,8 +1,8 @@
 ---
 import {getCollection} from 'astro:content';
-import MainLayout from "../../layouts/MainLayout.astro";
+import MainLayout from "../../../layouts/MainLayout.astro";
 export async function getStaticPaths() {
-    const entries = await getCollection('activity');
+    const entries = await getCollection('environment-type');
     return entries.map(entry => ({
         params: {slug: entry.slug}, props: {entry},
     }));
@@ -10,7 +10,7 @@ export async function getStaticPaths() {
 const {entry} = Astro.props;
 const {Content} = await entry.render();
 ---
-<MainLayout title={`${entry.data.title} | Activity`}>
+<MainLayout title={`${entry.data.title} | Ecosystem`}>
     <h1 data-pagefind-meta="title">{entry.data.title}</h1>
     <Content/>
 </MainLayout>

--- a/src/pages/taxonomy/environment-type/index.mdx
+++ b/src/pages/taxonomy/environment-type/index.mdx
@@ -1,9 +1,9 @@
 ---
-layout: ../../layouts/MainLayout.astro
+layout: ../../../layouts/MainLayout.astro
 title: Environment Type
 ---
 
-import TaxonomyTable from '../../components/taxonomy/TaxonomyTable.astro'
+import TaxonomyTable from '../../../components/taxonomy/TaxonomyTable.astro'
 
 # Environment Type Taxonomy
 

--- a/src/pages/taxonomy/impact/[...slug].astro
+++ b/src/pages/taxonomy/impact/[...slug].astro
@@ -1,8 +1,8 @@
 ---
 import {getCollection} from 'astro:content';
-import MainLayout from "../../layouts/MainLayout.astro";
+import MainLayout from "../../../layouts/MainLayout.astro";
 export async function getStaticPaths() {
-    const entries = await getCollection('environment-type');
+    const entries = await getCollection('impact');
     return entries.map(entry => ({
         params: {slug: entry.slug}, props: {entry},
     }));
@@ -10,7 +10,7 @@ export async function getStaticPaths() {
 const {entry} = Astro.props;
 const {Content} = await entry.render();
 ---
-<MainLayout title={`${entry.data.title} | Ecosystem`}>
+<MainLayout title={`${entry.data.title} | Impact`}>
     <h1 data-pagefind-meta="title">{entry.data.title}</h1>
     <Content/>
 </MainLayout>

--- a/src/pages/taxonomy/impact/index.mdx
+++ b/src/pages/taxonomy/impact/index.mdx
@@ -1,9 +1,9 @@
 ---
-layout: ../../layouts/MainLayout.astro
+layout: ../../../layouts/MainLayout.astro
 title: Impacts
 ---
 
-import TaxonomyTable from '../../components/taxonomy/TaxonomyTable.astro'
+import TaxonomyTable from '../../../components/taxonomy/TaxonomyTable.astro'
 
 # Impact Taxonomy
 


### PR DESCRIPTION
Standards-8: https://regennetwork.atlassian.net/jira/software/c/projects/ENG/boards/51?selectedIssue=STANDARDS-8

This takes some first steps at including LinkML schemas in this repo. I've only added the existing Project and ProjectPost linkml schemas I've worked on and didn't modify them in this process.

Overview of included changes:

For Schemas:
- Add a `schema` directory at root of this repo
- Provide linkml schemas in `*.yaml` format
- Use linkml [`gen-doc`](https://linkml.io/linkml/generators/markdown.html) utility to generate markdown files for the schema classes, slots (attributes) and data types. I have committed these generated markdown files (~50 total) here but this could potentially happen during a CI/CD build step?

For the Astro site:
- Add a `schema/[...slug]` dynamic route that loads the generated markdown files and renders them in an existing layout template. This is actually quite easy thanks to the [`Astro.glob()`](https://docs.astro.build/en/reference/api-reference/#astroglob) command which can load Markdown files from any directory and prepare them for rendering in a standard Astro component.
 - Add a `Schemas` item to the sidebar, right now just hard-code the top-level schema classes that are important, eg; `Project` and `Project Post`.
 - I started making some follow up changes to improve the sidebar (collapse by default) and change the taxonomy terms to have a `/taxonomy/{taxonomy}/{term}` path.
 
Things to review & some notes:
- For the schemas, I hope this demonstrates a simple first step at how this can be expanded to include core credit class, credit batch, etc types. Any Q's on how this would work?
- There are more schema specific features and options we could implement:
  - adding more descriptions (should do this)
  - providing example datasets (these examples would be included in generated docs)
  - include links to GH source LinkML schemas
- For integration with Astro, what do we think of this approach?
  - I considered trying to use astro's 'content collections' concept that is already implemented for taxonomy terms. In theory we could dump generated markdown into `src/content/schemas` but one downside is that the generated markdown doesn't include any frontmatter that these content collections expect you to have. It seems that we can provide jinja2 templates for the `gen-doc` command where we could potentially include frontmatter... but still, it's more work, and I think we want the schema markdown to follow a different editing flow than taxonomy terms, so it might be better to not use 'content collections'.
- I'm curious the latest thoughts on renaming this repo/site to "Framework" - it seems this might be in-line with the latest thinking on Registry 2.0 I'm just learning more about recently? IMO renaming to 'framework' makes a lot of sense! But with this, I'm curious the goals & types of users we want this page to serve. It's more technical, but how technical is too much? cc @beccaRND @S4mmyb 
- And re: URL paths and term names. I know there was discussion on this in Slack on this awhile back, but I don't think consensus was reached. Assuming we do want a single site that includes schemas, taxonomies, standards, etc. I think breaking down this site navigation to create some separation between each of these concepts will be necessary and thus would make sense to parallel this navigation in the URL paths. I don't see how 'longer urls' create any issues with how these things are used.