### PR TITLE
Integrate taxonomy with semantic enumerations

### DIFF
--- a/.github/workflows/pages-deployment.yaml
+++ b/.github/workflows/pages-deployment.yaml
@@ -19,6 +19,8 @@ jobs:
           cache: 'pip'
       - name: Install python dependencies
         run: pip install -r requirements.txt
+      - name: linkml gen-taxonomy
+        run: make -C schema gen-taxonomy
       - name: linkml lint
         run:  make -C schema lint
       - name: linkml gen-doc

--- a/.github/workflows/pages-deployment.yaml
+++ b/.github/workflows/pages-deployment.yaml
@@ -19,8 +19,6 @@ jobs:
           cache: 'pip'
       - name: Install python dependencies
         run: pip install -r requirements.txt
-      - name: linkml gen-taxonomy
-        run: make -C schema gen-taxonomy
       - name: linkml lint
         run:  make -C schema lint
       - name: linkml gen-doc

--- a/schema/Makefile
+++ b/schema/Makefile
@@ -1,3 +1,6 @@
+gen-taxonomy:
+	python3 scripts/populateSemanticEnums.py
+
 lint:
 	linkml-lint --validate src/ -a
 
@@ -10,4 +13,4 @@ gen-jsonld:
 validate:
 	linkml-validate -s src/TerrasosProjectInfo.yaml --target-class TerrasosProjectInfo data/TerrasosProjectInfoData.yaml
 
-all: lint gen-doc gen-jsonld validate
+all: gen-taxonomy lint gen-doc gen-jsonld validate

--- a/schema/README.md
+++ b/schema/README.md
@@ -13,8 +13,9 @@
 - Generated markdown from schemas:
     ```shell
     gen-doc schema/src/schemas.yaml --directory schema/generated --diagram-type er_diagram
+    make gen-doc
     ```
 - Generate linkml enums for taxonomy terms:
     ```shell
-    python populateSemanticEnums.py
+    make gen-taxonomy 
     ```

--- a/schema/README.md
+++ b/schema/README.md
@@ -12,5 +12,9 @@
 - Create separate schema files for each logical schema class and `import` into the root `schemas.yaml` file.
 - Generated markdown from schemas:
     ```shell
-    gen-doc schema/src/schemas.yml --directory schema/generated --diagram-type er_diagram
+    gen-doc schema/src/schemas.yaml --directory schema/generated --diagram-type er_diagram
+    ```
+- Generate linkml enums for taxonomy terms:
+    ```shell
+    python populateSemanticEnums.py
     ```

--- a/schema/data/TerrasosProjectInfoData.yaml
+++ b/schema/data/TerrasosProjectInfoData.yaml
@@ -28,7 +28,7 @@ biomeType:
 watershed: "Amazon River"
 subWatershed: "Upper Amazon"
 environmentType: 
-  - CLOUD_FOREST
+  - BOG
 projectDuration: "P1Y"
 creditClassVersion: "1.0"
 ecologicalConnectivityIndex: 75.5

--- a/schema/scripts/populateSemanticEnums.py
+++ b/schema/scripts/populateSemanticEnums.py
@@ -5,7 +5,7 @@ from linkml_runtime.utils.schemaview import SchemaView
 from linkml_runtime.dumpers import yaml_dumper
 
 # Load the taxonomy schema into a SchemaView.
-taxonomy_schema_path = "../src/taxonomy.yaml"
+taxonomy_schema_path = "src/taxonomy.yaml"
 view = SchemaView(taxonomy_schema_path)
 
 # Map each taxonomy to the linkml enum.
@@ -18,7 +18,7 @@ taxonomies = {
 # Load all taxonomy terms and add to the enums.
 for taxonomy, enum_name in taxonomies.items():
     enum = view.get_enum(enum_name)
-    md_files = glob.glob("**/*.md", root_dir=f"../../src/content/{taxonomy}", recursive=True)
+    md_files = glob.glob("**/*.md", root_dir=f"../src/content/{taxonomy}", recursive=True)
     for file in md_files:
         enum_text = file.split("/").pop().replace(".md", "").replace(" ", "")
         enum_value = PermissibleValue(

--- a/schema/scripts/populateSemanticEnums.py
+++ b/schema/scripts/populateSemanticEnums.py
@@ -1,0 +1,33 @@
+import glob
+
+from linkml_runtime.linkml_model import PermissibleValue
+from linkml_runtime.utils.schemaview import SchemaView
+from linkml_runtime.dumpers import yaml_dumper
+
+# Load the taxonomy schema into a SchemaView.
+taxonomy_schema_path = "../src/taxonomy.yaml"
+view = SchemaView(taxonomy_schema_path)
+
+# Map each taxonomy to the linkml enum.
+taxonomies = {
+    "activity": "ActivityTypes",
+    "environment-type": "EnvironmentTypeTypes",
+    "impact": "ImpactTypes",
+}
+
+# Load all taxonomy terms and add to the enums.
+for taxonomy, enum_name in taxonomies.items():
+    enum = view.get_enum(enum_name)
+    md_files = glob.glob("**/*.md", root_dir=f"../../src/content/{taxonomy}", recursive=True)
+    for file in md_files:
+        enum_text = file.split("/").pop().replace(".md", "").replace(" ", "")
+        enum_value = PermissibleValue(
+            title=enum_text,
+            text=enum_text,
+            meaning=f"rft:{enum_text}"
+        )
+        enum.permissible_values.update({enum_text: enum_value})
+
+# Write back changes to the taxonomy schema file.
+with open(taxonomy_schema_path, "w") as f:
+    f.write(yaml_dumper.dumps(view.schema))

--- a/schema/scripts/populateSemanticEnums.py
+++ b/schema/scripts/populateSemanticEnums.py
@@ -1,4 +1,5 @@
 import glob
+import re
 
 from linkml_runtime.linkml_model import PermissibleValue
 from linkml_runtime.utils.schemaview import SchemaView
@@ -20,13 +21,14 @@ for taxonomy, enum_name in taxonomies.items():
     enum = view.get_enum(enum_name)
     md_files = glob.glob("**/*.md", root_dir=f"../src/content/{taxonomy}", recursive=True)
     for file in md_files:
-        enum_text = file.split("/").pop().replace(".md", "").replace(" ", "")
+        enum_name = file.split("/").pop().replace(".md", "").replace(" ", "")
+        enum_key = re.sub('([A-Z])', r'_\1', enum_name).lstrip("_").upper()
         enum_value = PermissibleValue(
-            title=enum_text,
-            text=enum_text,
-            meaning=f"rft:{enum_text}"
+            title=enum_name,
+            text=enum_key,
+            meaning=f"rft:{enum_name}"
         )
-        enum.permissible_values.update({enum_text: enum_value})
+        enum.permissible_values.update({enum_key: enum_value})
 
 # Write back changes to the taxonomy schema file.
 with open(taxonomy_schema_path, "w") as f:

--- a/schema/src/ProjectInfo.yaml
+++ b/schema/src/ProjectInfo.yaml
@@ -9,6 +9,7 @@ prefixes:
   xsd: http://www.w3.org/2001/XMLSchema#
 imports:
   - linkml:types
+  - taxonomy
 default_curi_maps:
   - semweb_context
 default_prefix: rfs
@@ -30,6 +31,9 @@ classes:
       - projectStartDate # optional
       - projectEndDate # optional
       - creditClassVersion # optional
+      - activity # optional
+      - environmentType # optional
+      - impact # optional
   ProjectRole:
     slots:
       - name
@@ -176,103 +180,3 @@ enums:
         meaning: rfs:Individual
       ORGANIZATION:
         meaning: rfs:Organization
-  # TODO: these should be imported from a shared vocabulary
-  EnvironmentTypeTypes:
-    description: The type of ecosystem
-    permissible_values:
-      CLOUD_FOREST:
-        meaning: rfs:CloudForest
-      TROPICAL_SAVANNAH:
-        meaning: rfs:TropicalSavannah
-      TROPICAL_DRY_FOREST:
-        meaning: rfs:TropicalDryForest
-      TROPICAL_VERY_HUMID_FOREST:
-        meaning: rfs:TropicalVeryHumidForest
-      TROPICAL_HUMID_FOREST:
-        meaning: rfs:TropicalHumidForest
-      PREMONTANE_HUMID_FOREST:
-        meaning: rfs:PremontaneHumidForest
-      LOW_MONTANE_VERY_HUMID_FOREST:
-        meaning: rfs:LowMontaneVeryHumidForest
-      RIPARIAN_FOREST:
-        meaning: rfs:RiparianForest
-      AGROFORESTRY_SYSTEM:
-        meaning: rfs:AgroforestrySystem
-      AQUACULTURE_SYSTEM:
-        meaning: rfs:AquacultureSystem
-      CROPLAND:
-        meaning: rfs:Cropland
-      IRRIGATED_CROPLAND:
-        meaning: rfs:IrrigatedCropland
-      RAINFED_CROPLAND:
-        meaning: rfs:RainfedCropland
-      DESERT:
-        meaning: rfs:Desert
-      FOREST:
-        meaning: rfs:Forest
-      BOREAL_FOREST:
-        meaning: rfs:BorealForest
-      TEMPERATE_FOREST:
-        meaning: rfs:TemperateForest
-      TROPICAL_FOREST:
-        meaning: rfs:TropicalForest
-      FRESHWATER:
-        meaning: rfs:Freshwater
-      LAKE:
-        meaning: rfs:Lake
-      WATERCOURSE:
-        meaning: rfs:Watercourse
-      GRASSLAND:
-        meaning: rfs:Grassland
-      TEMPERATE_GRASSLAND:
-        meaning: rfs:TemperateGrassland
-      TROPICAL_GRASSLAND:
-        meaning: rfs:TropicalGrassland
-      TUNDRA:
-        meaning: rfs:Tundra
-      MARINE:
-        meaning: rfs:Marine
-      COASTAL:
-        meaning: rfs:Coastal
-      CORAL_REEF:
-        meaning: rfs:CoralReef
-      DEEP_WATER:
-        meaning: rfs:DeepWater
-      ORCHARD:
-        meaning: rfs:Orchard
-      PASTURE:
-        meaning: rfs:Pasture
-      PERMANENT_ICE:
-        meaning: rfs:PermanentIce
-      SAVANNA:
-        meaning: rfs:Savanna
-      SHRUBLAND:
-        meaning: rfs:Shrubland
-      BOREAL_SHRUBLAND:
-        meaning: rfs:BorealShrubland
-      TEMPERATE_SHRUBLAND:
-        meaning: rfs:TemperateShrubland
-      TROPICAL_SHRUBLAND:
-        meaning: rfs:TropicalShrubland
-      URBAN_TREES:
-        meaning: rfs:UrbanTrees
-      VINEYARD:
-        meaning: rfs:Vineyard
-      WETLAND:
-        meaning: rfs:Wetland
-      BOG:
-        meaning: rfs:Bog
-      MARSH:
-        meaning: rfs:Marsh
-      SWAMP:
-        meaning: rfs:Swamp
-  # TODO: these should be imported from a shared vocabulary
-  ActivityTypes:
-    description: The type of activity
-    permissible_values:
-      CONSERVATION:
-        meaning: rfs:Conservation
-        description: a conservation activity
-      ECOSYSTEM_RESTORATION:
-        meaning: rfs:EcosystemRestoration
-        description: an ecosystem restoration activity

--- a/schema/src/schemas.yaml
+++ b/schema/src/schemas.yaml
@@ -11,6 +11,7 @@ imports:
   - ProjectInfo
   - ProjectPost
   - TerrasosProjectInfo
+  - taxonomy
 default_curi_maps:
   - semweb_context
 default_prefix: rfs

--- a/schema/src/taxonomy.yaml
+++ b/schema/src/taxonomy.yaml
@@ -1,0 +1,49 @@
+name: Taxonomy
+id: https://framework.regen.network/taxonomy/
+prefixes:
+  rfs:
+    prefix_prefix: rfs
+    prefix_reference: https://framework.regen.network/schema/
+  rft:
+    prefix_prefix: rft
+    prefix_reference: https://framework.regen.network/taxonomy/
+default_curi_maps:
+- semweb_context
+default_prefix: rfs
+default_range: string
+enums:
+  ActivityTypes:
+    name: ActivityTypes
+    from_schema: https://framework.regen.network/taxonomy/
+    permissible_values:
+  EnvironmentTypeTypes:
+    name: EnvironmentTypeTypes
+    from_schema: https://framework.regen.network/taxonomy/
+    permissible_values:
+  ImpactTypes:
+    name: ImpactTypes
+    from_schema: https://framework.regen.network/taxonomy/
+    permissible_values:
+slots:
+  activity:
+    name: activity
+    description: The types of activities being implemented in projects
+    from_schema: https://framework.regen.network/taxonomy/
+    slot_uri: rfs:activity
+    range: ActivityTypes
+    multivalued: true
+  environmentType:
+    name: environmentType
+    description: General classification of the project's environment type.
+    from_schema: https://framework.regen.network/taxonomy/
+    slot_uri: rfs:environmentType
+    range: EnvironmentTypeTypes
+    multivalued: true
+  impact:
+    name: impact
+    description: A project or initiative’s current and potential impact
+    from_schema: https://framework.regen.network/taxonomy/
+    slot_uri: rfs:impact
+    range: ImpactTypes
+    multivalued: true
+source_file: ../src/taxonomy.yaml

--- a/schema/src/taxonomy.yaml
+++ b/schema/src/taxonomy.yaml
@@ -46,4 +46,4 @@ slots:
     slot_uri: rfs:impact
     range: ImpactTypes
     multivalued: true
-source_file: ../src/taxonomy.yaml
+source_file: src/taxonomy.yaml

--- a/schema/src/taxonomy.yaml
+++ b/schema/src/taxonomy.yaml
@@ -16,14 +16,334 @@ enums:
     name: ActivityTypes
     from_schema: https://framework.regen.network/taxonomy/
     permissible_values:
+      RESIDUE_TILLAGE_MANAGEMENT:
+        text: RESIDUE_TILLAGE_MANAGEMENT
+        meaning: rft:ResidueTillageManagement
+        title: ResidueTillageManagement
+      BIOCHAR_PRODUCTION:
+        text: BIOCHAR_PRODUCTION
+        meaning: rft:BiocharProduction
+        title: BiocharProduction
+      IMPROVED_FOREST_MANAGEMENT:
+        text: IMPROVED_FOREST_MANAGEMENT
+        meaning: rft:ImprovedForestManagement
+        title: ImprovedForestManagement
+      AGROFORESTRY:
+        text: AGROFORESTRY
+        meaning: rft:Agroforestry
+        title: Agroforestry
+      PRESCRIBED_GRAZING:
+        text: PRESCRIBED_GRAZING
+        meaning: rft:PrescribedGrazing
+        title: PrescribedGrazing
+      RIPARIAN_FOREST_BUFFERS:
+        text: RIPARIAN_FOREST_BUFFERS
+        meaning: rft:RiparianForestBuffers
+        title: RiparianForestBuffers
+      SOIL_AMENDMENTS:
+        text: SOIL_AMENDMENTS
+        meaning: rft:SoilAmendments
+        title: SoilAmendments
+      CONSERVATION:
+        text: CONSERVATION
+        meaning: rft:Conservation
+        title: Conservation
+      ECOTOURISM:
+        text: ECOTOURISM
+        meaning: rft:Ecotourism
+        title: Ecotourism
+      COVER_CROPPING:
+        text: COVER_CROPPING
+        meaning: rft:CoverCropping
+        title: CoverCropping
+      TREE_PLANTING:
+        text: TREE_PLANTING
+        meaning: rft:TreePlanting
+        title: TreePlanting
+      PHOTOCATALYST_APPLICATION:
+        text: PHOTOCATALYST_APPLICATION
+        meaning: rft:PhotocatalystApplication
+        title: PhotocatalystApplication
+      ECOSYSTEM_RESTORATION:
+        text: ECOSYSTEM_RESTORATION
+        meaning: rft:EcosystemRestoration
+        title: EcosystemRestoration
+      INDUSTRIAL_BIOCHAR_PRODUCTION:
+        text: INDUSTRIAL_BIOCHAR_PRODUCTION
+        meaning: rft:IndustrialBiocharProduction
+        title: IndustrialBiocharProduction
+      ARTISANAL_BIOCHAR_PRODUCTION:
+        text: ARTISANAL_BIOCHAR_PRODUCTION
+        meaning: rft:ArtisanalBiocharProduction
+        title: ArtisanalBiocharProduction
+      BIOCHAR:
+        text: BIOCHAR
+        meaning: rft:Biochar
+        title: Biochar
+      ENHANCED_ROCK_WEATHERING:
+        text: ENHANCED_ROCK_WEATHERING
+        meaning: rft:EnhancedRockWeathering
+        title: EnhancedRockWeathering
+      COMPOST_AMENDMENTS:
+        text: COMPOST_AMENDMENTS
+        meaning: rft:CompostAmendments
+        title: CompostAmendments
+      KEYSTONE_SPECIES_CONSERVATION:
+        text: KEYSTONE_SPECIES_CONSERVATION
+        meaning: rft:KeystoneSpeciesConservation
+        title: KeystoneSpeciesConservation
+      UMBRELLA_SPECIES_CONSERVATION:
+        text: UMBRELLA_SPECIES_CONSERVATION
+        meaning: rft:UmbrellaSpeciesConservation
+        title: UmbrellaSpeciesConservation
+      SILVOPASTURE:
+        text: SILVOPASTURE
+        meaning: rft:Silvopasture
+        title: Silvopasture
+      FOREST_FARMING:
+        text: FOREST_FARMING
+        meaning: rft:ForestFarming
+        title: ForestFarming
+      NON_URBAN_FOREST_IMPROVEMENT:
+        text: NON_URBAN_FOREST_IMPROVEMENT
+        meaning: rft:NonUrbanForestImprovement
+        title: NonUrbanForestImprovement
+      URBAN_FOREST_IMPROVEMENT:
+        text: URBAN_FOREST_IMPROVEMENT
+        meaning: rft:UrbanForestImprovement
+        title: UrbanForestImprovement
+      AFFORESTATION:
+        text: AFFORESTATION
+        meaning: rft:Afforestation
+        title: Afforestation
+      REFORESTATION:
+        text: REFORESTATION
+        meaning: rft:Reforestation
+        title: Reforestation
   EnvironmentTypeTypes:
     name: EnvironmentTypeTypes
     from_schema: https://framework.regen.network/taxonomy/
     permissible_values:
+      MARINE:
+        text: MARINE
+        meaning: rft:Marine
+        title: Marine
+      CROPLAND:
+        text: CROPLAND
+        meaning: rft:Cropland
+        title: Cropland
+      URBAN_TREES:
+        text: URBAN_TREES
+        meaning: rft:UrbanTrees
+        title: UrbanTrees
+      SHRUBLAND:
+        text: SHRUBLAND
+        meaning: rft:Shrubland
+        title: Shrubland
+      PASTURE:
+        text: PASTURE
+        meaning: rft:Pasture
+        title: Pasture
+      SAVANNA:
+        text: SAVANNA
+        meaning: rft:Savanna
+        title: Savanna
+      GRASSLAND:
+        text: GRASSLAND
+        meaning: rft:Grassland
+        title: Grassland
+      AGROFORESTRY_SYSTEM:
+        text: AGROFORESTRY_SYSTEM
+        meaning: rft:AgroforestrySystem
+        title: AgroforestrySystem
+      PERMANENT_ICE:
+        text: PERMANENT_ICE
+        meaning: rft:PermanentIce
+        title: PermanentIce
+      WETLAND:
+        text: WETLAND
+        meaning: rft:Wetland
+        title: Wetland
+      FRESHWATER:
+        text: FRESHWATER
+        meaning: rft:Freshwater
+        title: Freshwater
+      ORCHARD:
+        text: ORCHARD
+        meaning: rft:Orchard
+        title: Orchard
+      AQUACULTURE_SYSTEM:
+        text: AQUACULTURE_SYSTEM
+        meaning: rft:AquacultureSystem
+        title: AquacultureSystem
+      VINEYARD:
+        text: VINEYARD
+        meaning: rft:Vineyard
+        title: Vineyard
+      DESERT:
+        text: DESERT
+        meaning: rft:Desert
+        title: Desert
+      FOREST:
+        text: FOREST
+        meaning: rft:Forest
+        title: Forest
+      IRRIGATED_CROPLAND:
+        text: IRRIGATED_CROPLAND
+        meaning: rft:IrrigatedCropland
+        title: IrrigatedCropland
+      RAINFED_CROPLAND:
+        text: RAINFED_CROPLAND
+        meaning: rft:RainfedCropland
+        title: RainfedCropland
+      TEMPERATE_SHRUBLAND:
+        text: TEMPERATE_SHRUBLAND
+        meaning: rft:TemperateShrubland
+        title: TemperateShrubland
+      BOREAL_SHRUBLAND:
+        text: BOREAL_SHRUBLAND
+        meaning: rft:BorealShrubland
+        title: BorealShrubland
+      TROPICAL_SHRUBLAND:
+        text: TROPICAL_SHRUBLAND
+        meaning: rft:TropicalShrubland
+        title: TropicalShrubland
+      MARSH:
+        text: MARSH
+        meaning: rft:Marsh
+        title: Marsh
+      BOG:
+        text: BOG
+        meaning: rft:Bog
+        title: Bog
+      SWAMP:
+        text: SWAMP
+        meaning: rft:Swamp
+        title: Swamp
+      TROPICAL_FOREST:
+        text: TROPICAL_FOREST
+        meaning: rft:TropicalForest
+        title: TropicalForest
+      TEMPERATE_FOREST:
+        text: TEMPERATE_FOREST
+        meaning: rft:TemperateForest
+        title: TemperateForest
+      BOREAL_FOREST:
+        text: BOREAL_FOREST
+        meaning: rft:BorealForest
+        title: BorealForest
+      COASTAL:
+        text: COASTAL
+        meaning: rft:Coastal
+        title: Coastal
+      DEEP_WATER:
+        text: DEEP_WATER
+        meaning: rft:DeepWater
+        title: DeepWater
+      CORAL_REEF:
+        text: CORAL_REEF
+        meaning: rft:CoralReef
+        title: CoralReef
+      TEMPERATE_GRASSLAND:
+        text: TEMPERATE_GRASSLAND
+        meaning: rft:TemperateGrassland
+        title: TemperateGrassland
+      TUNDRA:
+        text: TUNDRA
+        meaning: rft:Tundra
+        title: Tundra
+      TROPICAL_GRASSLAND:
+        text: TROPICAL_GRASSLAND
+        meaning: rft:TropicalGrassland
+        title: TropicalGrassland
+      LAKE:
+        text: LAKE
+        meaning: rft:Lake
+        title: Lake
+      WATERCOURSE:
+        text: WATERCOURSE
+        meaning: rft:Watercourse
+        title: Watercourse
   ImpactTypes:
     name: ImpactTypes
     from_schema: https://framework.regen.network/taxonomy/
     permissible_values:
+      REDUCED_FERTILIZER_AMENDMENTS:
+        text: REDUCED_FERTILIZER_AMENDMENTS
+        meaning: rft:ReducedFertilizerAmendments
+        title: ReducedFertilizerAmendments
+      AVOIDED_DEFORESTATION_DEGRADATION:
+        text: AVOIDED_DEFORESTATION_DEGRADATION
+        meaning: rft:AvoidedDeforestationDegradation
+        title: AvoidedDeforestationDegradation
+      IMPROVED_CULTURAL_HERITAGE_AWARENESS:
+        text: IMPROVED_CULTURAL_HERITAGE_AWARENESS
+        meaning: rft:ImprovedCulturalHeritageAwareness
+        title: ImprovedCulturalHeritageAwareness
+      IMPROVED_BIODIVERSITY:
+        text: IMPROVED_BIODIVERSITY
+        meaning: rft:ImprovedBiodiversity
+        title: ImprovedBiodiversity
+      IMPROVED_ENVIRONMENTAL_EDUCATION_OUTREACH:
+        text: IMPROVED_ENVIRONMENTAL_EDUCATION_OUTREACH
+        meaning: rft:ImprovedEnvironmentalEducationOutreach
+        title: ImprovedEnvironmentalEducationOutreach
+      REDUCED_SOIL_EROSION:
+        text: REDUCED_SOIL_EROSION
+        meaning: rft:ReducedSoilErosion
+        title: ReducedSoilErosion
+      REDUCED_HERBICIDE_AMENDMENTS:
+        text: REDUCED_HERBICIDE_AMENDMENTS
+        meaning: rft:ReducedHerbicideAmendments
+        title: ReducedHerbicideAmendments
+      IMPROVED_FOREST_HEALTH:
+        text: IMPROVED_FOREST_HEALTH
+        meaning: rft:ImprovedForestHealth
+        title: ImprovedForestHealth
+      IMPROVED_COMMUNITY_HEALTH:
+        text: IMPROVED_COMMUNITY_HEALTH
+        meaning: rft:ImprovedCommunityHealth
+        title: ImprovedCommunityHealth
+      IMPROVED_WILDLIFE_HABITAT:
+        text: IMPROVED_WILDLIFE_HABITAT
+        meaning: rft:ImprovedWildlifeHabitat
+        title: ImprovedWildlifeHabitat
+      IMPROVED_SOIL_HEALTH:
+        text: IMPROVED_SOIL_HEALTH
+        meaning: rft:ImprovedSoilHealth
+        title: ImprovedSoilHealth
+      INCREASED_FOREST_COVER:
+        text: INCREASED_FOREST_COVER
+        meaning: rft:IncreasedForestCover
+        title: IncreasedForestCover
+      REDUCED_PESTICIDE_AMENDMENTS:
+        text: REDUCED_PESTICIDE_AMENDMENTS
+        meaning: rft:ReducedPesticideAmendments
+        title: ReducedPesticideAmendments
+      IMPROVED_WATER_INFILTRATION:
+        text: IMPROVED_WATER_INFILTRATION
+        meaning: rft:ImprovedWaterInfiltration
+        title: ImprovedWaterInfiltration
+      IMPROVED_WATER_HOLDING_CAPACITY:
+        text: IMPROVED_WATER_HOLDING_CAPACITY
+        meaning: rft:ImprovedWaterHoldingCapacity
+        title: ImprovedWaterHoldingCapacity
+      INCREASED_CARBON_SEQUESTRATION_STORAGE:
+        text: INCREASED_CARBON_SEQUESTRATION_STORAGE
+        meaning: rft:IncreasedCarbonSequestrationStorage
+        title: IncreasedCarbonSequestrationStorage
+      REDUCED_IRRIGATION:
+        text: REDUCED_IRRIGATION
+        meaning: rft:ReducedIrrigation
+        title: ReducedIrrigation
+      IMPROVED_SOIL_STRUCTURE:
+        text: IMPROVED_SOIL_STRUCTURE
+        meaning: rft:ImprovedSoilStructure
+        title: ImprovedSoilStructure
+      IMPROVED_NUTRIENT_CYCLING:
+        text: IMPROVED_NUTRIENT_CYCLING
+        meaning: rft:ImprovedNutrientCycling
+        title: ImprovedNutrientCycling
 slots:
   activity:
     name: activity


### PR DESCRIPTION
This PR integrates framework taxonomy terms into the schemas using [semantic enumerations](https://linkml.io/linkml/schemas/enums.html).

This works by using a simple python script to populate a new `taxonomy.yaml` schema file with enum values from the curated list of taxonomy terms. This was easy to do since Linkml provides a python API for interacting with schemas, [SchemaView](https://linkml.io/linkml/developers/schemaview.html). I also considered manipulating the `taxonomy.yaml` file more manually but got this working so didn't explore that any further.

I added simple `activity`, `impact` and `environmentType` slots to the Project class just so these terms get pulled into the documentation in a meaningful way... I imagine we might want to reference these enums via different or even multiple slots? I left some related comments in #8