### PR TITLE
Improve layout

### DIFF
--- a/src/components/topbar/Topbar.astro
+++ b/src/components/topbar/Topbar.astro
@@ -3,7 +3,7 @@ import {Image} from 'astro:assets';
 import logo from "../../assets/regen.png";
 import Search from "astro-pagefind/components/Search";
 ---
-<header class="flex flex-row py-2 px-3 bg-brand-300 justify-between items-center sticky w-screen"
+<header class="flex flex-row py-2 px-3 bg-brand-300 justify-between items-center sticky w-full"
         data-pagefind-ignore="all">
     <div class="flex flex-row gap-4 items-center">
         <Image src={logo} alt="Regen Network" width="20" height="20"/>

--- a/src/components/topbar/Topbar.astro
+++ b/src/components/topbar/Topbar.astro
@@ -3,7 +3,7 @@ import {Image} from 'astro:assets';
 import logo from "../../assets/regen.png";
 import Search from "astro-pagefind/components/Search";
 ---
-<header class="flex flex-row py-2 px-3 bg-brand-300 justify-between items-center sticky w-full"
+<header class="flex flex-row py-2 px-3 h-16 bg-brand-300 justify-between items-center sticky w-full"
         data-pagefind-ignore="all">
     <div class="flex flex-row gap-4 items-center">
         <Image src={logo} alt="Regen Network" width="20" height="20"/>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -19,7 +19,7 @@ title = frontmatter ? frontmatter.title : title;
     <Sidebar/>
     <div id="main" class="grow px-16 py-8 prose max-w-none overflow-y-auto">
         <p class="bg-warning-200 italic p-2 rounded-md">WARNING: This site is a work in progress.<p>
-        <main data-pagefind-body>
+        <main data-pagefind-body class="mx-auto lg:max-w-screen-lg">
             <slot/>
         </main>
     </div>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -17,7 +17,7 @@ title = frontmatter ? frontmatter.title : title;
 <Topbar/>
 <div class="flex h-[calc(100vh-64px)]">
     <Sidebar/>
-    <div id="main" class="px-16 py-8 prose overflow-y-auto">
+    <div id="main" class="grow px-16 py-8 prose max-w-none overflow-y-auto">
         <p class="bg-warning-200 italic p-2 rounded-md">WARNING: This site is a work in progress.<p>
         <main data-pagefind-body>
             <slot/>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -15,7 +15,7 @@ title = frontmatter ? frontmatter.title : title;
 </head>
 <body>
 <Topbar/>
-<div class="flex h-screen">
+<div class="flex h-[calc(100vh-64px)]">
     <Sidebar/>
     <div id="main" class="px-16 py-8 prose overflow-y-auto">
         <p class="bg-warning-200 italic p-2 rounded-md">WARNING: This site is a work in progress.<p>


### PR DESCRIPTION
Fixes #30 

This removes the unnecessary horizontal and vertical scrollbars due to using `w-screen` and `h-screen` tailwind classes.

Also changes the main content container to `grow` to a lg width. And a slight change to keep the scroll bar on the far-right of the screen, not inside the main content container.