### PR TITLE
feat: Claim and Attestation schemas for claims engine interop

### DIFF
--- a/schema/src/Attestation.yaml
+++ b/schema/src/Attestation.yaml
@@ -1,0 +1,75 @@
+id: Attestation
+name: Attestation
+prefixes:
+  linkml: https://w3id.org/linkml/
+  rfs: https://framework.regen.network/schema/
+  rft: https://framework.regen.network/taxonomy/
+
+imports:
+  - linkml:types
+  - core
+  - taxonomy
+  - Entity
+
+default_prefix: rfs
+default_range: string
+
+classes:
+  Attestation:
+    description: >-
+      A reviewer's attestation about a Claim. Maps to the KOI
+      claim_attestations table and aligns with on-chain MsgAttest
+      and Ethereum Attestation Service (EAS) attestation patterns.
+    slots:
+      - name
+      - description
+    attributes:
+      attestsClaim:
+        slot_uri: rfs:attestsClaim
+        description: >-
+          Reference to the Claim being attested, by RID or IRI.
+        range: string
+        required: true
+      hasReviewer:
+        slot_uri: rfs:hasReviewer
+        description: >-
+          The entity providing the attestation. Must have a registered
+          identity (KOI entity URI and/or wallet address).
+        range: Entity
+        required: true
+        inlined: true
+      hasVerdict:
+        slot_uri: rfs:hasVerdict
+        description: >-
+          The reviewer's verdict on the claim.
+        range: VerdictType
+        required: true
+      rationale:
+        slot_uri: rfs:rationale
+        description: >-
+          Free-text explanation of the verdict, including any conditions
+          or caveats noted during review.
+        range: string
+      evidenceReviewed:
+        slot_uri: rfs:evidenceReviewed
+        description: >-
+          URIs of evidence documents, datasets, or field observations
+          reviewed as part of this attestation.
+        range: uri
+        multivalued: true
+      attestationDate:
+        slot_uri: rfs:attestationDate
+        description: Date when the attestation was made.
+        range: date
+      contentHash:
+        slot_uri: rfs:contentHash
+        description: >-
+          BLAKE2b-256 content hash of the canonical attestation
+          representation, used for on-chain anchoring.
+        range: string
+      graphIri:
+        slot_uri: rfs:graphIri
+        description: >-
+          On-chain graph IRI from Regen Data Module MsgAttest,
+          using ContentHash.Graph encoding.
+        range: uri

--- a/schema/src/Claim.yaml
+++ b/schema/src/Claim.yaml
@@ -133,4 +133,4 @@ classes:
         description: >-
           IRI or RID of a previous claim that this claim supersedes,
           forming a version chain.
-        range: uri
+        range: uriorcurie

--- a/schema/src/Claim.yaml
+++ b/schema/src/Claim.yaml
@@ -1,0 +1,136 @@
+id: Claim
+name: Claim
+prefixes:
+  linkml: https://w3id.org/linkml/
+  rfs: https://framework.regen.network/schema/
+  rft: https://framework.regen.network/taxonomy/
+  schema: http://schema.org/
+  qudt: http://qudt.org/schema/qudt/
+  unit: http://qudt.org/vocab/unit/
+
+imports:
+  - linkml:types
+  - core
+  - taxonomy
+  - Entity
+  - Impact
+  - SDG
+  - Methodology
+
+default_prefix: rfs
+default_range: string
+
+classes:
+  Claim:
+    description: >-
+      A verifiable claim about ecological, social, or financial outcomes
+      associated with a place, practice, or project. Claims are the atomic
+      unit of the regenerative claims engine, linking a claimant's assertion
+      to a subject entity with typed impact and temporal bounds.
+    slots:
+      - name
+      - description
+      - url
+    slot_usage:
+      name:
+        required: true
+        description: Human-readable title of the claim.
+    attributes:
+      hasClaimType:
+        slot_uri: rfs:hasClaimType
+        description: >-
+          The primary category of the claim, drawn from the FWG ClaimType
+          taxonomy. Determines which verification pathways apply.
+        range: ClaimType
+        required: true
+      hasClaimant:
+        slot_uri: rfs:hasClaimant
+        description: >-
+          The entity making the claim. May be an individual, organization,
+          or community.
+        range: Entity
+        required: true
+        inlined: true
+      hasSubject:
+        slot_uri: rfs:hasSubject
+        description: >-
+          The entity or place about which the claim is made. Often a project,
+          land steward, or community.
+        range: Entity
+        required: true
+        inlined: true
+      hasOperator:
+        slot_uri: rfs:hasOperator
+        description: >-
+          The entity responsible for operations that produced the claimed
+          outcome, if different from the claimant.
+        range: Entity
+        inlined: true
+      hasPrimaryImpact:
+        slot_uri: rfs:hasPrimaryImpact
+        description: The primary impact claimed.
+        range: Impact
+        required: true
+        inlined: true
+      hasCoBenefits:
+        description: Secondary impacts or co-benefits associated with the claim.
+        range: Impact
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+      verificationStatus:
+        slot_uri: rfs:verificationStatus
+        description: >-
+          Current verification state of the claim, from self-reported through
+          ledger-anchored.
+        range: VerificationStatus
+        required: true
+      claimStartDate:
+        slot_uri: schema:startDate
+        description: The start date of the period covered by this claim.
+        range: date
+      claimEndDate:
+        slot_uri: schema:endDate
+        description: The end date of the period covered by this claim.
+        range: date
+      quantity:
+        slot_uri: rfs:quantity
+        description: >-
+          Numeric quantity associated with the claim (e.g., tonnes CO2e,
+          hectares restored).
+        range: float
+      quantityUnit:
+        slot_uri: qudt:unit
+        description: >-
+          Unit of measurement for the quantity (e.g., unit:TON, unit:HA).
+        range: string
+      usesMethodology:
+        description: The methodology used to measure or verify the claimed outcome.
+        range: Methodology
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+      hasCreditClass:
+        slot_uri: rfs:hasCreditClass
+        description: >-
+          Credit class identifier (e.g., C01, C06) linking this claim to
+          a registered credit class on Regen Ledger.
+        range: string
+      contentHash:
+        slot_uri: rfs:contentHash
+        description: >-
+          BLAKE2b-256 content hash of the canonical claim representation,
+          used for on-chain anchoring via Regen Data Module.
+        range: string
+      dataIri:
+        slot_uri: rfs:dataIri
+        description: >-
+          Regen Data Module IRI derived from the content hash. Bridges the
+          off-chain claim to its on-chain anchor.
+        range: uri
+      supersedes:
+        slot_uri: rfs:supersedes
+        description: >-
+          IRI or RID of a previous claim that this claim supersedes,
+          forming a version chain.
+        range: uri

--- a/schema/src/Entity.yaml
+++ b/schema/src/Entity.yaml
@@ -25,6 +25,13 @@ classes:
       type:
         range: EntityTypes
         required: true
+      walletAddress:
+        slot_uri: rfs:walletAddress
+        description: >-
+          On-chain wallet address (bech32 or hex) bridging semantic identity
+          to signing capability. Used by the identity bridge to link KOI
+          entity URIs to on-chain accounts for CLAMS and EAS interop.
+        range: string
 
 enums:
   EntityTypes:
@@ -33,3 +40,8 @@ enums:
         meaning: rfs:Individual
       ORGANIZATION:
         meaning: rfs:Organization
+      COMMUNITY:
+        meaning: rfs:Community
+        description: >-
+          A collective entity such as a community, cooperative, or indigenous
+          group acting as a unified identity for claims and governance.

--- a/schema/src/schema.yaml
+++ b/schema/src/schema.yaml
@@ -20,6 +20,8 @@ imports:
   - Methodology
   - Registry
   - CreditClassInfo
+  - Claim
+  - Attestation
   - BT01ProjectInfo
   - C01ProjectInfo
   - C02ProjectInfo

--- a/schema/src/taxonomy.yaml
+++ b/schema/src/taxonomy.yaml
@@ -342,3 +342,93 @@ enums:
       UNKNOWN:
         text: UNKNOWN
         title: Unknown
+  ClaimType:
+    name: ClaimType
+    description: >-
+      Categories of claims that can be made about regenerative outcomes.
+      Determines which verification pathways and impact metrics apply.
+    from_schema: https://framework.regen.network/taxonomy/
+    permissible_values:
+      ECOLOGICAL:
+        text: ECOLOGICAL
+        meaning: rft:Ecological
+        title: Ecological
+        description: Claims about ecological outcomes such as carbon sequestration, biodiversity, soil health, or water quality.
+      SOCIAL:
+        text: SOCIAL
+        meaning: rft:Social
+        title: Social
+        description: Claims about social outcomes such as community well-being, livelihoods, education, or cultural preservation.
+      FINANCIAL:
+        text: FINANCIAL
+        meaning: rft:Financial
+        title: Financial
+        description: Claims about financial outcomes such as revenue generation, cost savings, or investment returns from regenerative practices.
+      GOVERNANCE:
+        text: GOVERNANCE
+        meaning: rft:Governance
+        title: Governance
+        description: Claims about governance outcomes such as stakeholder participation, decision-making processes, or institutional arrangements.
+      BIOCULTURAL:
+        text: BIOCULTURAL
+        meaning: rft:Biocultural
+        title: Biocultural
+        description: Claims about biocultural outcomes integrating ecological and cultural dimensions, such as traditional ecological knowledge or indigenous stewardship.
+  VerificationStatus:
+    name: VerificationStatus
+    description: >-
+      Lifecycle states of a claim as it moves through verification.
+      Each state represents increasing levels of assurance.
+    from_schema: https://framework.regen.network/taxonomy/
+    permissible_values:
+      SELF_REPORTED:
+        text: SELF_REPORTED
+        meaning: rft:SelfReported
+        title: SelfReported
+        description: Claim submitted by the claimant without independent review.
+      PEER_REVIEWED:
+        text: PEER_REVIEWED
+        meaning: rft:PeerReviewed
+        title: PeerReviewed
+        description: Claim reviewed by one or more peer attestors.
+      VERIFIED:
+        text: VERIFIED
+        meaning: rft:Verified
+        title: Verified
+        description: Claim verified by an accredited or authorized verifier.
+      LEDGER_ANCHORED:
+        text: LEDGER_ANCHORED
+        meaning: rft:LedgerAnchored
+        title: LedgerAnchored
+        description: Claim anchored on-chain via Regen Data Module with a content hash.
+      WITHDRAWN:
+        text: WITHDRAWN
+        meaning: rft:Withdrawn
+        title: Withdrawn
+        description: Claim withdrawn by the claimant or invalidated through review.
+  VerdictType:
+    name: VerdictType
+    description: >-
+      Possible verdicts an attestor can assign when reviewing a claim.
+    from_schema: https://framework.regen.network/taxonomy/
+    permissible_values:
+      PENDING:
+        text: PENDING
+        meaning: rft:Pending
+        title: Pending
+        description: Attestation is in progress; no verdict has been rendered yet.
+      APPROVED:
+        text: APPROVED
+        meaning: rft:Approved
+        title: Approved
+        description: The claim has been reviewed and approved by the attestor.
+      REJECTED:
+        text: REJECTED
+        meaning: rft:Rejected
+        title: Rejected
+        description: The claim has been reviewed and rejected by the attestor.
+      NEEDS_INFO:
+        text: NEEDS_INFO
+        meaning: rft:NeedsInfo
+        title: NeedsInfo
+        description: The attestor requires additional information or evidence before rendering a verdict.


### PR DESCRIPTION
## Summary

Adds Claim and Attestation LinkML schemas as the semantic backbone for KOI (off-chain) and CLAMS (on-chain) claims engine interoperability, per ADR-004.

- **`Claim.yaml`** — verifiable claims with typed impact, temporal bounds, entity references (claimant/subject/operator), quantity + unit, methodology, credit class link, and chain bridge fields (contentHash, dataIri)
- **`Attestation.yaml`** — reviewer attestations with verdict, rationale, evidence URIs, and on-chain anchoring (contentHash, graphIri for MsgAttest)
- **3 new enums in `taxonomy.yaml`**: ClaimType (ECOLOGICAL, SOCIAL, FINANCIAL, GOVERNANCE, BIOCULTURAL), VerificationStatus (SELF_REPORTED → LEDGER_ANCHORED), VerdictType (PENDING, APPROVED, REJECTED, NEEDS_INFO)
- **`Entity.yaml` extensions**: `walletAddress` attribute (identity bridge for CLAMS/EAS), `COMMUNITY` entity type (PACTO collective entities)
- **`schema.yaml`**: Claim and Attestation added to imports

### Design decisions

| Decision | Rationale |
|----------|-----------|
| Entity refs use `range: Entity, inlined: true` | Matches ProjectInfo patterns (hasProjectDeveloper, etc.) |
| Taxonomy refs follow `eligibleActivities → ActivityType` pattern | Consistent with CreditClassInfo |
| Temporal bounds as explicit date attributes | Not buried in metadata JSONB — queryable and validatable |
| Quantity promoted to typed `float` + unit `string` | Enables SPARQL aggregation across claims |
| `contentHash` + `dataIri` on both Claim and Attestation | Bridges off-chain semantic data to on-chain Regen Data Module |
| `hasCreditClass` as string (not inlined CreditClassInfo) | References credit class by ID (e.g., C01) — lightweight link |
| Omitted `tx_hash`, `ledger_timestamp` | Operational fields, not semantic — belong in implementation layer |

### Verification

- `linkml-lint` passes (warnings only — all pre-existing camelCase convention warnings)
- `gen-json-schema` generates valid JSON Schema with all new types
- `gen-jsonld-context` generates JSON-LD context with Claim/Attestation resolvable

### Merge conflict note

PR #51 (`feat/governance-schema-extensions`) touches Entity.yaml (adds `AGENT` to EntityTypes), taxonomy.yaml (adds governance enums), and schema.yaml (adds governance imports). Our changes are **additive to different sections** — trivially resolvable after #51 merges.

### Downstream consumers

- **KOI claims engine** (gaiaaiagent/koi-processor#11): `@context` + taxonomy validation
- **CLAMS CosmWasm contract** (Spec B): JSON-LD deliverable builds on this context
- **PACTO**: biocultural claims use BIOCULTURAL ClaimType + COMMUNITY entity
- **RI Pod**: PAMEL-QB pricing references Claim schema for outcome verification

Closes #52

## Test plan

- [ ] `linkml-lint` passes on full schema (no new errors)
- [ ] `gen-json-schema` generates valid output including Claim and Attestation
- [ ] `gen-jsonld-context` generates context with new types
- [ ] Existing schemas still validate (no regressions)
- [ ] `make` in `schema/` completes without errors (after #51 merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)