### PR TITLE
fix(ci): pin linkml-runtime==1.9.5 to restore CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 linkml==1.8.6
+# Pin linkml-runtime — 1.10.0 renamed Format.JSON → Format.JSONLD,
+# which breaks linkml==1.8.6's __init__.py (calls Format.JSON).
+# 1.9.5 is the last release compatible with the pinned linkml.
+linkml-runtime==1.9.5


### PR DESCRIPTION
## Summary

Pins `linkml-runtime==1.9.5` in `requirements.txt` so the CI workflows can install a working LinkML toolchain again.

## Why CI is currently red on every PR

`linkml-runtime` 1.10.0 renamed the `Format.JSON` enum member to `Format.JSONLD`. The repo pins `linkml==1.8.6`, and `linkml`'s `__init__.py` calls `Format.JSON` at import time. With no pin on `linkml-runtime`, pip resolves the latest (1.10+) and any import — including `linkml-lint` and `linkml-convert` — explodes with:

```
AttributeError: type object 'Format' has no attribute 'JSON'. Did you mean: 'JSONLD'?
```

That single import error takes out both workflows:

- **Deploy to Cloudflare Pages** (`pages-deployment.yaml`) — `make -C schema lint` fails immediately
- **Validate and Convert data** (`sparql-playground.yaml`) — every `linkml-convert` invocation in `schema/scripts/gen-rdf.sh` fails for every playground YAML

This is why #33, #50, #51, and #53 are all sitting on red checks today — the failures are environmental, not caused by any of those PRs' diffs.

## Fix

`linkml-runtime==1.9.5` is the last release before the rename and pairs cleanly with `linkml==1.8.6`. Added a comment in `requirements.txt` explaining the constraint so future upgrades don't strip it without thought. Longer-term, bumping `linkml` itself to a release that uses `Format.JSONLD` is the right cleanup, but that's a wider change and shouldn't gate the open PRs.

## Verification (local)

Same install path as CI (`pip install -r requirements.txt`, Python 3.10/3.12), run against both `main` and PR #53's branch (`feat/claims-attestation-schemas`):

- `make -C schema lint` → `✓ No problems found`
- `make -C schema gen-rdf` → `116/116 passed, 0 failed`
- `make -C schema gen-doc` → completes (existing `None` print is pre-existing, not introduced)

## Test plan

- [ ] CI is green on this PR
- [ ] Rebase / re-run CI on #51 and #53 — both should now pass their schema checks